### PR TITLE
Fix controller manager labeling

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,10 +24,11 @@ metadata:
     app.kubernetes.io/created-by: barbican-operator
     app.kubernetes.io/part-of: barbican-operator
     app.kubernetes.io/managed-by: kustomize
+    openstack.org/operator-name: barbican
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      openstack.org/operator-name: barbican
   replicas: 1
   template:
     metadata:
@@ -35,6 +36,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        openstack.org/operator-name: barbican
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -23,4 +23,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      openstack.org/operator-name: barbican

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -18,4 +18,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: controller-manager
+    openstack.org/operator-name: barbican


### PR DESCRIPTION
We now have a final form for operator controller-manager pod labeling of the format `openstack.org/operator-name: <operator name>` and are no longer relying on the inconsistent labels created by various `operator-sdk` versions.  All operators that lack this standardized pattern are being updated.