### PR TITLE
Reset Ready condition when update failed

### DIFF
--- a/api/v1beta1/barbican_types.go
+++ b/api/v1beta1/barbican_types.go
@@ -101,10 +101,9 @@ type Barbican struct {
 	Status BarbicanStatus `json:"status,omitempty"`
 }
 
-// IsReady returns true when both API and Worker are ready
+// IsReady - returns true if Barbican is reconciled successfully
 func (instance Barbican) IsReady() bool {
-	return instance.Status.Conditions.IsTrue(BarbicanAPIReadyCondition) &&
-		instance.Status.Conditions.IsTrue(BarbicanWorkerReadyCondition)
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }
 
 //+kubebuilder:object:root=true

--- a/controllers/barbican_controller.go
+++ b/controllers/barbican_controller.go
@@ -92,11 +92,18 @@ func (r *BarbicanReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		// update the overall status condition if service is ready
-		if instance.IsReady() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
+		// update the Ready condition based on the sub conditions
+		if instance.Status.Conditions.AllSubConditionIsTrue() {
+			instance.Status.Conditions.MarkTrue(
+				condition.ReadyCondition, condition.ReadyMessage)
+		} else {
+			// something is not ready so reset the Ready condition
+			instance.Status.Conditions.MarkUnknown(
+				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
+			// and recalculate it based on the state of the rest of the conditions
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
-
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err


### PR DESCRIPTION
This ensures the Ready Condition is reset when CR becomes once ready but something fails during reconfiguration.