### PR TITLE
Fix defaulting of Replicas spec

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -67,7 +67,7 @@ type BarbicanComponentTemplate struct {
 	// +kubebuilder:validation:Maximum=32
 	// +kubebuilder:validation:Minimum=0
 	// Replicas of Barbican API to run
-	Replicas int32 `json:"replicas"`
+	Replicas *int32 `json:"replicas"`
 
 	// +kubebuilder:validation:Optional
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -177,6 +177,11 @@ func (in *BarbicanComponentTemplate) DeepCopyInto(out *BarbicanComponentTemplate
 			(*out)[key] = val
 		}
 	}
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
+	}
 	if in.DefaultConfigOverwrite != nil {
 		in, out := &in.DefaultConfigOverwrite, &out.DefaultConfigOverwrite
 		*out = make(map[string]string, len(*in))

--- a/config/samples/barbican_v1beta1_barbican.yaml
+++ b/config/samples/barbican_v1beta1_barbican.yaml
@@ -35,7 +35,6 @@ spec:
     containerImage: some_image
     nodeSelector:
       optional_override: here
-    replicas: 10
     customServiceConfig: |
       [optional]
       overrides = True
@@ -55,7 +54,6 @@ spec:
     containerImage: some_image
     nodeSelector:
       optional_override: here
-    replicas: 10
     customServiceConfig: |
       [optional]
       overrides = True

--- a/config/samples/barbican_v1beta1_barbican.yaml
+++ b/config/samples/barbican_v1beta1_barbican.yaml
@@ -32,7 +32,6 @@ spec:
     policy.json: |
       {"some": "custom policy"}
   barbicanAPI:
-    containerImage: some_image
     nodeSelector:
       optional_override: here
     customServiceConfig: |
@@ -51,7 +50,6 @@ spec:
         loadBalancerIPs:
           - some_ip_string
   barbicanWorker:
-    containerImage: some_image
     nodeSelector:
       optional_override: here
     customServiceConfig: |


### PR DESCRIPTION
Currently the default values are ignored because these specs are set to 0 by webhook. Update the type from int32 to *int32 to avoid that behavior and ensure the expected default values are used.

This also removes the large replicas set in the sample config, because these are not suitable for testing.