### PR TITLE
Fix inconsistent password selector value for service password

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -33,7 +33,7 @@ type BarbicanTemplate struct {
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: BarbicanDatabasePassword, service: BarbicanServiceUserPassword}
+	// +kubebuilder:default={database: BarbicanDatabasePassword, service: BarbicanPassword}
 	// TODO(dmendiza): Maybe we'll add SimpleCrypto key here?
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
@@ -93,7 +93,7 @@ type PasswordSelector struct {
 	// Database - Selector to get the barbican database user password from the Secret
 	Database string `json:"database"`
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="BarbicanServiceUserPassword"
+	// +kubebuilder:default="BarbicanPassword"
 	// Service - Selector to get the barbican service user password from the Secret
 	Service string `json:"service"`
 

--- a/config/crd/bases/barbican.openstack.org_barbicanapis.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicanapis.yaml
@@ -147,7 +147,7 @@ spec:
               passwordSelectors:
                 default:
                   database: BarbicanDatabasePassword
-                  service: BarbicanServiceUserPassword
+                  service: BarbicanPassword
                 description: 'TODO(dmendiza): Maybe we''ll add SimpleCrypto key here?
                   PasswordSelectors - Selectors to identify the DB and ServiceUser
                   password from the Secret'
@@ -158,7 +158,7 @@ spec:
                       user password from the Secret
                     type: string
                   service:
-                    default: BarbicanServiceUserPassword
+                    default: BarbicanPassword
                     description: Service - Selector to get the barbican service user
                       password from the Secret
                     type: string

--- a/config/crd/bases/barbican.openstack.org_barbicans.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicans.yaml
@@ -230,7 +230,7 @@ spec:
               passwordSelectors:
                 default:
                   database: BarbicanDatabasePassword
-                  service: BarbicanServiceUserPassword
+                  service: BarbicanPassword
                 description: 'TODO(dmendiza): Maybe we''ll add SimpleCrypto key here?
                   PasswordSelectors - Selectors to identify the DB and ServiceUser
                   password from the Secret'
@@ -241,7 +241,7 @@ spec:
                       user password from the Secret
                     type: string
                   service:
-                    default: BarbicanServiceUserPassword
+                    default: BarbicanPassword
                     description: Service - Selector to get the barbican service user
                       password from the Secret
                     type: string

--- a/config/crd/bases/barbican.openstack.org_barbicanworkers.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicanworkers.yaml
@@ -104,7 +104,7 @@ spec:
               passwordSelectors:
                 default:
                   database: BarbicanDatabasePassword
-                  service: BarbicanServiceUserPassword
+                  service: BarbicanPassword
                 description: 'TODO(dmendiza): Maybe we''ll add SimpleCrypto key here?
                   PasswordSelectors - Selectors to identify the DB and ServiceUser
                   password from the Secret'
@@ -115,7 +115,7 @@ spec:
                       user password from the Secret
                     type: string
                   service:
-                    default: BarbicanServiceUserPassword
+                    default: BarbicanPassword
                     description: Service - Selector to get the barbican service user
                       password from the Secret
                     type: string


### PR DESCRIPTION
We use <Service Name>Password for service user passwords globally.