### PR TITLE
Fix operator build

### DIFF
--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,6 +1,4 @@
 ## Append samples you want in your CSV to this file as resources ##
 resources:
-- barbican_v1beta1_barbicanapi.yaml
 - barbican_v1beta1_barbican.yaml
-- barbican_v1beta1_barbicanworker.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
Two sample files were removed that are needed for the operator build to succeed [1] [2].  Without them this error is encountered:

```
$ IMAGE_TAG_BASE=quay.io/andrewbays/barbican-operator VERSION=0.0.1 IMG=$IMAGE_TAG_BASE:v$VERSION make manifests build docker-build docker-push bundle bundle-build bundle-push catalog-build catalog-push
...
Error: accumulating resources: 2 errors occurred:
	* accumulateFile error: "accumulating resources from '../samples': '/home/ocp/podified/barbican-operator/config/samples' must resolve to a file"
	* accumulateDirector error: "recursed accumulation of path '/home/ocp/podified/barbican-operator/config/samples': accumulating resources: 2 errors occurred:\n\t* accumulateFile error: \"accumulating resources from 'barbican_v1beta1_barbicanapi.yaml': evalsymlink failure on '/home/ocp/podified/barbican-operator/config/samples/barbican_v1beta1_barbicanapi.yaml' : lstat /home/ocp/podified/barbican-operator/config/samples/barbican_v1beta1_barbicanapi.yaml: no such file or directory\"\n\t* loader.New error: \"error loading barbican_v1beta1_barbicanapi.yaml with git: url lacks orgRepo: barbican_v1beta1_barbicanapi.yaml, dir: evalsymlink failure on '/home/ocp/podified/barbican-operator/config/samples/barbican_v1beta1_barbicanapi.yaml' : lstat /home/ocp/podified/barbican-operator/config/samples/barbican_v1beta1_barbicanapi.yaml: no such file or directory, get: invalid source string: barbican_v1beta1_barbicanapi.yaml\"\n\n"
```

We have opted to remove those files from being referenced, which fixes the build.

[1] https://github.com/openstack-k8s-operators/barbican-operator/blob/41d26e9842110e20727073e2159b5172882e3ad3/config/samples/kustomization.yaml#L3
[2] https://github.com/openstack-k8s-operators/barbican-operator/blob/41d26e9842110e20727073e2159b5172882e3ad3/config/samples/kustomization.yaml#L5