### PR TITLE
Add missing RBAC config

### DIFF
--- a/config/rbac/barbicankeystonelistener_editor_role.yaml
+++ b/config/rbac/barbicankeystonelistener_editor_role.yaml
@@ -1,0 +1,31 @@
+# permissions for end users to edit barbicankeystonelisteners.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: barbicankeystonelistener-editor-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: barbican-operator
+    app.kubernetes.io/part-of: barbican-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: barbicankeystonelistener-editor-role
+rules:
+- apiGroups:
+  - barbican.openstack.org
+  resources:
+  - barbicankeystonelisteners
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - barbican.openstack.org
+  resources:
+  - barbicankeystonelisteners/status
+  verbs:
+  - get

--- a/config/rbac/barbicankeystonelistener_viewer_role.yaml
+++ b/config/rbac/barbicankeystonelistener_viewer_role.yaml
@@ -1,0 +1,27 @@
+# permissions for end users to view barbicankeystonelisteners.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: barbicankeystonelistener-viewer-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: barbican-operator
+    app.kubernetes.io/part-of: barbican-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: barbicankeystonelistener-viewer-role
+rules:
+- apiGroups:
+  - barbican.openstack.org
+  resources:
+  - barbicankeystonelisteners
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - barbican.openstack.org
+  resources:
+  - barbicankeystonelisteners/status
+  verbs:
+  - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -80,6 +80,58 @@ rules:
   - patch
   - update
 - apiGroups:
+  - barbican.openstack.org
+  resources:
+  - barbicanworkers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - barbican.openstack.org
+  resources:
+  - barbicanworkers/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - barbican.openstack.org
+  resources:
+  - barbicanworkers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - barbican.openstack.org
+  resources:
+  - barbicankeystonelisteners
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - barbican.openstack.org
+  resources:
+  - barbicankeystonelisteners/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - barbican.openstack.org
+  resources:
+  - barbicankeystonelisteners/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - batch
   resources:
   - jobs

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -56,6 +56,32 @@ rules:
 - apiGroups:
   - barbican.openstack.org
   resources:
+  - barbicankeystonelisteners
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - barbican.openstack.org
+  resources:
+  - barbicankeystonelisteners/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - barbican.openstack.org
+  resources:
+  - barbicankeystonelisteners/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - barbican.openstack.org
+  resources:
   - barbicans
   verbs:
   - create
@@ -101,32 +127,6 @@ rules:
   - barbican.openstack.org
   resources:
   - barbicanworkers/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - barbican.openstack.org
-  resources:
-  - barbicankeystonelisteners
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - barbican.openstack.org
-  resources:
-  - barbicankeystonelisteners/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - barbican.openstack.org
-  resources:
-  - barbicankeystonelisteners/status
   verbs:
   - get
   - patch

--- a/controllers/barbican_controller.go
+++ b/controllers/barbican_controller.go
@@ -65,6 +65,15 @@ type BarbicanReconciler struct {
 //+kubebuilder:rbac:groups=barbican.openstack.org,resources=barbicans,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=barbican.openstack.org,resources=barbicans/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=barbican.openstack.org,resources=barbicans/finalizers,verbs=update
+//+kubebuilder:rbac:groups=barbican.openstack.org,resources=barbicanapis,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=barbican.openstack.org,resources=barbicanapis/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=barbican.openstack.org,resources=barbicanapis/finalizers,verbs=update
+//+kubebuilder:rbac:groups=barbican.openstack.org,resources=barbicanworkers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=barbican.openstack.org,resources=barbicanworkers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=barbican.openstack.org,resources=barbicanworkers/finalizers,verbs=update
+//+kubebuilder:rbac:groups=barbican.openstack.org,resources=barbicankeystonelisteners,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=barbican.openstack.org,resources=barbicankeystonelisteners/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=barbican.openstack.org,resources=barbicankeystonelisteners/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete;
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete;
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete;


### PR DESCRIPTION
This patch adds the missing RBAC config for BarbicanWorker and BarbicanKeystoneListner that is causing the controller to get stuck in a crash loop.