### PR TITLE
Remove duplicated ContainerImage

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -13,10 +13,6 @@ type BarbicanTemplate struct {
 	ServiceUser string `json:"serviceUser"`
 
 	// +kubebuilder:validation:Required
-	// Barbican Container Image URL (will be set to environmental default if empty)
-	ContainerImage string `json:"containerImage"`
-
-	// +kubebuilder:validation:Required
 	// MariaDB instance name
 	// TODO(dmendiza): Is this comment right?
 	// Right now required by the maridb-operator to get the credentials from the instance to create the DB

--- a/config/crd/bases/barbican.openstack.org_barbicanapis.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicanapis.yaml
@@ -36,8 +36,8 @@ spec:
             description: BarbicanAPISpec defines the desired state of BarbicanAPI
             properties:
               containerImage:
-                description: Barbican Container Image URL (will be set to environmental
-                  default if empty)
+                description: ContainerImage - Barbican Container Image URL (will be
+                  set to environmental default if empty)
                 type: string
               customServiceConfig:
                 description: CustomServiceConfig - customize the service config using

--- a/config/crd/bases/barbican.openstack.org_barbicankeystonelisteners.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicankeystonelisteners.yaml
@@ -38,8 +38,8 @@ spec:
               BarbicanKeystoneListener
             properties:
               containerImage:
-                description: Barbican Container Image URL (will be set to environmental
-                  default if empty)
+                description: ContainerImage - Barbican Container Image URL (will be
+                  set to environmental default if empty)
                 type: string
               customServiceConfig:
                 description: CustomServiceConfig - customize the service config using

--- a/config/crd/bases/barbican.openstack.org_barbicans.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicans.yaml
@@ -529,10 +529,6 @@ spec:
                 required:
                 - containerImage
                 type: object
-              containerImage:
-                description: Barbican Container Image URL (will be set to environmental
-                  default if empty)
-                type: string
               customServiceConfig:
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
@@ -637,7 +633,6 @@ spec:
             - barbicanAPI
             - barbicanKeystoneListener
             - barbicanWorker
-            - containerImage
             - databaseInstance
             - rabbitMqClusterName
             - serviceAccount

--- a/config/crd/bases/barbican.openstack.org_barbicanworkers.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicanworkers.yaml
@@ -36,8 +36,8 @@ spec:
             description: BarbicanWorkerSpec defines the desired state of BarbicanWorker
             properties:
               containerImage:
-                description: Barbican Container Image URL (will be set to environmental
-                  default if empty)
+                description: ContainerImage - Barbican Container Image URL (will be
+                  set to environmental default if empty)
                 type: string
               customServiceConfig:
                 description: CustomServiceConfig - customize the service config using


### PR DESCRIPTION
This patch removes the ContainerImage property from BarbicanTemplate to avoid a name collision with BarbicanComponentTemplate in components that inline both templates.