### PR TITLE
Add CRDs under api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,8 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
+	rm -f api/bases/* && cp -a config/crd/bases api/
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/api/bases/barbican.openstack.org_barbicanapis.yaml
+++ b/api/bases/barbican.openstack.org_barbicanapis.yaml
@@ -1,0 +1,468 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.1
+  creationTimestamp: null
+  name: barbicanapis.barbican.openstack.org
+spec:
+  group: barbican.openstack.org
+  names:
+    kind: BarbicanAPI
+    listKind: BarbicanAPIList
+    plural: barbicanapis
+    singular: barbicanapi
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: BarbicanAPI is the Schema for the barbicanapis API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BarbicanAPISpec defines the desired state of BarbicanAPI
+            properties:
+              containerImage:
+                description: ContainerImage - Barbican Container Image URL (will be
+                  set to environmental default if empty)
+                type: string
+              customServiceConfig:
+                description: CustomServiceConfig - customize the service config using
+                  this parameter to change service defaults, or overwrite rendered
+                  information using raw OpenStack config format. The content gets
+                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
+                  file.
+                type: string
+              customServiceConfigSecrets:
+                description: CustomServiceConfigSecrets - customize the service config
+                  using this parameter to specify Secrets that contain sensitive service
+                  config data. The content of each Secret gets added to the /etc/<service>/<service>.conf.d
+                  directory as a custom config file.
+                items:
+                  type: string
+                type: array
+              databaseHostname:
+                description: DatabaseHostname - Barbican Database Hostname
+                type: string
+              databaseInstance:
+                description: 'MariaDB instance name TODO(dmendiza): Is this comment
+                  right? Right now required by the maridb-operator to get the credentials
+                  from the instance to create the DB Might not be required in future'
+                type: string
+              databaseUser:
+                default: barbican
+                description: DatabaseUser - optional username used for barbican DB,
+                  defaults to barbican
+                type: string
+              debug:
+                description: 'Debug - enable debug for different deploy stages. If
+                  an init container is used, it runs and the actual action pod gets
+                  started with sleep infinity TODO(dmendiza): Do we need this?'
+                properties:
+                  dbInitContainer:
+                    default: false
+                    description: dbInitContainer enable debug (waits until /tmp/stop-init-container
+                      disappears)
+                    type: boolean
+                  dbSync:
+                    default: false
+                    description: dbSync enable debug
+                    type: boolean
+                  initContainer:
+                    default: false
+                    description: initContainer enable debug (waits until /tmp/stop-init-container
+                      disappears)
+                    type: boolean
+                  service:
+                    default: false
+                    description: Service enable debug
+                    type: boolean
+                type: object
+              defaultConfigOverwrite:
+                additionalProperties:
+                  type: string
+                description: 'ConfigOverwrite - interface to overwrite default config
+                  files like e.g. policy.json. But can also be used to add additional
+                  files. Those get added to the service config dir in /etc/<service>
+                  . TODO: -> implement'
+                type: object
+              networkAttachments:
+                description: NetworkAttachments is a list of NetworkAttachment resource
+                  names to expose the services to the given network
+                items:
+                  type: string
+                type: array
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector to target subset of worker nodes running
+                  this component. Setting here overrides any global NodeSelector settings
+                  within the Barbican CR.
+                type: object
+              override:
+                description: Override, provides the ability to override the generated
+                  manifest of several child resources.
+                properties:
+                  service:
+                    additionalProperties:
+                      description: RoutedOverrideSpec - a routed service override
+                        configuration for the Service created to serve traffic to
+                        the cluster. Allows for the manifest of the created Service
+                        to be overwritten with custom configuration.
+                      properties:
+                        endpointURL:
+                          type: string
+                        metadata:
+                          description: EmbeddedLabelsAnnotations is an embedded subset
+                            of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.
+                            Only labels and annotations are included.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: 'Annotations is an unstructured key value
+                                map stored with a resource that may be set by external
+                                tools to store and retrieve arbitrary metadata. They
+                                are not queryable and should be preserved when modifying
+                                objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: 'Map of string keys and values that can
+                                be used to organize and categorize (scope and select)
+                                objects. May match selectors of replication controllers
+                                and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                              type: object
+                          type: object
+                        spec:
+                          description: OverrideServiceSpec is a subset of the fields
+                            included in https://pkg.go.dev/k8s.io/api@v0.26.6/core/v1#ServiceSpec
+                            Limited to Type, SessionAffinity, LoadBalancerSourceRanges,
+                            ExternalName, ExternalTrafficPolicy, SessionAffinityConfig,
+                            IPFamilyPolicy, LoadBalancerClass and InternalTrafficPolicy
+                          properties:
+                            externalName:
+                              description: externalName is the external reference
+                                that discovery mechanisms will return as an alias
+                                for this service (e.g. a DNS CNAME record). No proxying
+                                will be involved.  Must be a lowercase RFC-1123 hostname
+                                (https://tools.ietf.org/html/rfc1123) and requires
+                                `type` to be "ExternalName".
+                              type: string
+                            externalTrafficPolicy:
+                              description: externalTrafficPolicy describes how nodes
+                                distribute service traffic they receive on one of
+                                the Service's "externally-facing" addresses (NodePorts,
+                                ExternalIPs, and LoadBalancer IPs). If set to "Local",
+                                the proxy will configure the service in a way that
+                                assumes that external load balancers will take care
+                                of balancing the service traffic between nodes, and
+                                so each node will deliver traffic only to the node-local
+                                endpoints of the service, without masquerading the
+                                client source IP. (Traffic mistakenly sent to a node
+                                with no endpoints will be dropped.) The default value,
+                                "Cluster", uses the standard behavior of routing to
+                                all endpoints evenly (possibly modified by topology
+                                and other features). Note that traffic sent to an
+                                External IP or LoadBalancer IP from within the cluster
+                                will always get "Cluster" semantics, but clients sending
+                                to a NodePort from within the cluster may need to
+                                take traffic policy into account when picking a node.
+                              type: string
+                            internalTrafficPolicy:
+                              description: InternalTrafficPolicy describes how nodes
+                                distribute service traffic they receive on the ClusterIP.
+                                If set to "Local", the proxy will assume that pods
+                                only want to talk to endpoints of the service on the
+                                same node as the pod, dropping the traffic if there
+                                are no local endpoints. The default value, "Cluster",
+                                uses the standard behavior of routing to all endpoints
+                                evenly (possibly modified by topology and other features).
+                              type: string
+                            ipFamilyPolicy:
+                              description: IPFamilyPolicy represents the dual-stack-ness
+                                requested or required by this Service. If there is
+                                no value provided, then this field will be set to
+                                SingleStack. Services can be "SingleStack" (a single
+                                IP family), "PreferDualStack" (two IP families on
+                                dual-stack configured clusters or a single IP family
+                                on single-stack clusters), or "RequireDualStack" (two
+                                IP families on dual-stack configured clusters, otherwise
+                                fail). The ipFamilies and clusterIPs fields depend
+                                on the value of this field. This field will be wiped
+                                when updating a service to type ExternalName.
+                              type: string
+                            loadBalancerClass:
+                              description: loadBalancerClass is the class of the load
+                                balancer implementation this Service belongs to. If
+                                specified, the value of this field must be a label-style
+                                identifier, with an optional prefix, e.g. "internal-vip"
+                                or "example.com/internal-vip". Unprefixed names are
+                                reserved for end-users. This field can only be set
+                                when the Service type is 'LoadBalancer'. If not set,
+                                the default load balancer implementation is used,
+                                today this is typically done through the cloud provider
+                                integration, but should apply for any default implementation.
+                                If set, it is assumed that a load balancer implementation
+                                is watching for Services with a matching class. Any
+                                default load balancer implementation (e.g. cloud providers)
+                                should ignore Services that set this field. This field
+                                can only be set when creating or updating a Service
+                                to type 'LoadBalancer'. Once set, it can not be changed.
+                                This field will be wiped when a service is updated
+                                to a non 'LoadBalancer' type.
+                              type: string
+                            loadBalancerSourceRanges:
+                              description: 'If specified and supported by the platform,
+                                this will restrict traffic through the cloud-provider
+                                load-balancer will be restricted to the specified
+                                client IPs. This field will be ignored if the cloud-provider
+                                does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+                              items:
+                                type: string
+                              type: array
+                            sessionAffinity:
+                              description: 'Supports "ClientIP" and "None". Used to
+                                maintain session affinity. Enable client IP based
+                                session affinity. Must be ClientIP or None. Defaults
+                                to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              type: string
+                            sessionAffinityConfig:
+                              description: sessionAffinityConfig contains the configurations
+                                of session affinity.
+                              properties:
+                                clientIP:
+                                  description: clientIP contains the configurations
+                                    of Client IP based session affinity.
+                                  properties:
+                                    timeoutSeconds:
+                                      description: timeoutSeconds specifies the seconds
+                                        of ClientIP type session sticky time. The
+                                        value must be >0 && <=86400(for 1 day) if
+                                        ServiceAffinity == "ClientIP". Default value
+                                        is 10800(for 3 hours).
+                                      format: int32
+                                      type: integer
+                                  type: object
+                              type: object
+                            type:
+                              description: 'type determines how the Service is exposed.
+                                Defaults to ClusterIP. Valid options are ExternalName,
+                                ClusterIP, NodePort, and LoadBalancer. "ClusterIP"
+                                allocates a cluster-internal IP address for load-balancing
+                                to endpoints. Endpoints are determined by the selector
+                                or if that is not specified, by manual construction
+                                of an Endpoints object or EndpointSlice objects. If
+                                clusterIP is "None", no virtual IP is allocated and
+                                the endpoints are published as a set of endpoints
+                                rather than a virtual IP. "NodePort" builds on ClusterIP
+                                and allocates a port on every node which routes to
+                                the same endpoints as the clusterIP. "LoadBalancer"
+                                builds on NodePort and creates an external load-balancer
+                                (if supported in the current cloud) which routes to
+                                the same endpoints as the clusterIP. "ExternalName"
+                                aliases this service to the specified externalName.
+                                Several other fields do not apply to ExternalName
+                                services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                              type: string
+                          type: object
+                      type: object
+                    description: Override configuration for the Service created to
+                      serve traffic to the cluster. The key must be the endpoint type
+                      (public, internal)
+                    type: object
+                type: object
+              passwordSelectors:
+                default:
+                  database: BarbicanDatabasePassword
+                  service: BarbicanPassword
+                description: 'TODO(dmendiza): Maybe we''ll add SimpleCrypto key here?
+                  PasswordSelectors - Selectors to identify the DB and ServiceUser
+                  password from the Secret'
+                properties:
+                  database:
+                    default: BarbicanDatabasePassword
+                    description: Database - Selector to get the barbican database
+                      user password from the Secret
+                    type: string
+                  service:
+                    default: BarbicanPassword
+                    description: Service - Selector to get the barbican service user
+                      password from the Secret
+                    type: string
+                type: object
+              rabbitMqClusterName:
+                default: rabbitmq
+                description: RabbitMQ instance name Needed to request a transportURL
+                  that is created and used in Barbican
+                type: string
+              replicas:
+                default: 1
+                description: Replicas of Barbican API to run
+                format: int32
+                maximum: 32
+                minimum: 0
+                type: integer
+              resources:
+                description: Resources - Compute Resources required by this service
+                  (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                properties:
+                  claims:
+                    description: "Claims lists the names of resources, defined in
+                      spec.resourceClaims, that are used by this container. \n This
+                      is an alpha field and requires enabling the DynamicResourceAllocation
+                      feature gate. \n This field is immutable. It can only be set
+                      for containers."
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: Name must match the name of one entry in pod.spec.resourceClaims
+                            of the Pod where this field is used. It makes that resource
+                            available inside a container.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              secret:
+                description: Secret containing all passwords / keys needed
+                type: string
+              serviceAccount:
+                description: ServiceAccount - service account name used internally
+                  to provide Barbican services the default SA name
+                type: string
+              serviceUser:
+                default: barbican
+                description: ServiceUser - optional username used for this service
+                  to register in keystone
+                type: string
+              simpleCryptoBackendKEKSecret:
+                description: Secret containing SimpleCrypto KEK
+                type: string
+              transportURLSecret:
+                description: TransportURLSecret - Secret containing RabbitMQ transportURL
+                type: string
+            required:
+            - containerImage
+            - databaseHostname
+            - databaseInstance
+            - rabbitMqClusterName
+            - serviceAccount
+            type: object
+          status:
+            description: BarbicanAPIStatus defines the observed state of BarbicanAPI
+            properties:
+              apiEndpoint:
+                additionalProperties:
+                  type: string
+                description: API endpoint
+                type: object
+              conditions:
+                description: Conditions
+                items:
+                  description: Condition defines an observation of a API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase.
+                      type: string
+                    severity:
+                      description: Severity provides a classification of Reason code,
+                        so the current situation is immediately understandable and
+                        could act accordingly. It is meant for situations where Status=False
+                        and it should be indicated if it is just informational, warning
+                        (next reconciliation might fix it) or an error (e.g. DB create
+                        issue and no actions to automatically resolve the issue can/should
+                        be done). For conditions where Status=Unknown or Status=True
+                        the Severity should be SeverityNone.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              databaseHostname:
+                description: Barbican Database Hostname
+                type: string
+              hash:
+                additionalProperties:
+                  type: string
+                description: Map of hashes to track e.g. job status
+                type: object
+              networkAttachments:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: NetworkAttachments status of the deployment pods
+                type: object
+              readyCount:
+                description: ReadyCount of barbican API instances
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/api/bases/barbican.openstack.org_barbicankeystonelisteners.yaml
+++ b/api/bases/barbican.openstack.org_barbicankeystonelisteners.yaml
@@ -1,0 +1,292 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.1
+  creationTimestamp: null
+  name: barbicankeystonelisteners.barbican.openstack.org
+spec:
+  group: barbican.openstack.org
+  names:
+    kind: BarbicanKeystoneListener
+    listKind: BarbicanKeystoneListenerList
+    plural: barbicankeystonelisteners
+    singular: barbicankeystonelistener
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: BarbicanKeystoneListener is the Schema for the barbicankeystonelistener
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BarbicanKeystoneListenerSpec defines the desired state of
+              BarbicanKeystoneListener
+            properties:
+              containerImage:
+                description: ContainerImage - Barbican Container Image URL (will be
+                  set to environmental default if empty)
+                type: string
+              customServiceConfig:
+                description: CustomServiceConfig - customize the service config using
+                  this parameter to change service defaults, or overwrite rendered
+                  information using raw OpenStack config format. The content gets
+                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
+                  file.
+                type: string
+              customServiceConfigSecrets:
+                description: CustomServiceConfigSecrets - customize the service config
+                  using this parameter to specify Secrets that contain sensitive service
+                  config data. The content of each Secret gets added to the /etc/<service>/<service>.conf.d
+                  directory as a custom config file.
+                items:
+                  type: string
+                type: array
+              databaseHostname:
+                type: string
+              databaseInstance:
+                description: 'MariaDB instance name TODO(dmendiza): Is this comment
+                  right? Right now required by the maridb-operator to get the credentials
+                  from the instance to create the DB Might not be required in future'
+                type: string
+              databaseUser:
+                default: barbican
+                description: DatabaseUser - optional username used for barbican DB,
+                  defaults to barbican
+                type: string
+              debug:
+                description: 'Debug - enable debug for different deploy stages. If
+                  an init container is used, it runs and the actual action pod gets
+                  started with sleep infinity TODO(dmendiza): Do we need this?'
+                properties:
+                  dbInitContainer:
+                    default: false
+                    description: dbInitContainer enable debug (waits until /tmp/stop-init-container
+                      disappears)
+                    type: boolean
+                  dbSync:
+                    default: false
+                    description: dbSync enable debug
+                    type: boolean
+                  initContainer:
+                    default: false
+                    description: initContainer enable debug (waits until /tmp/stop-init-container
+                      disappears)
+                    type: boolean
+                  service:
+                    default: false
+                    description: Service enable debug
+                    type: boolean
+                type: object
+              defaultConfigOverwrite:
+                additionalProperties:
+                  type: string
+                description: 'ConfigOverwrite - interface to overwrite default config
+                  files like e.g. policy.json. But can also be used to add additional
+                  files. Those get added to the service config dir in /etc/<service>
+                  . TODO: -> implement'
+                type: object
+              networkAttachments:
+                description: NetworkAttachments is a list of NetworkAttachment resource
+                  names to expose the services to the given network
+                items:
+                  type: string
+                type: array
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector to target subset of worker nodes running
+                  this component. Setting here overrides any global NodeSelector settings
+                  within the Barbican CR.
+                type: object
+              passwordSelectors:
+                default:
+                  database: BarbicanDatabasePassword
+                  service: BarbicanPassword
+                description: 'TODO(dmendiza): Maybe we''ll add SimpleCrypto key here?
+                  PasswordSelectors - Selectors to identify the DB and ServiceUser
+                  password from the Secret'
+                properties:
+                  database:
+                    default: BarbicanDatabasePassword
+                    description: Database - Selector to get the barbican database
+                      user password from the Secret
+                    type: string
+                  service:
+                    default: BarbicanPassword
+                    description: Service - Selector to get the barbican service user
+                      password from the Secret
+                    type: string
+                type: object
+              rabbitMqClusterName:
+                default: rabbitmq
+                description: RabbitMQ instance name Needed to request a transportURL
+                  that is created and used in Barbican
+                type: string
+              replicas:
+                default: 1
+                description: Replicas of Barbican API to run
+                format: int32
+                maximum: 32
+                minimum: 0
+                type: integer
+              resources:
+                description: Resources - Compute Resources required by this service
+                  (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                properties:
+                  claims:
+                    description: "Claims lists the names of resources, defined in
+                      spec.resourceClaims, that are used by this container. \n This
+                      is an alpha field and requires enabling the DynamicResourceAllocation
+                      feature gate. \n This field is immutable. It can only be set
+                      for containers."
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: Name must match the name of one entry in pod.spec.resourceClaims
+                            of the Pod where this field is used. It makes that resource
+                            available inside a container.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              secret:
+                description: Secret containing all passwords / keys needed
+                type: string
+              serviceAccount:
+                description: ServiceAccount - service account name used internally
+                  to provide Barbican services the default SA name
+                type: string
+              serviceUser:
+                default: barbican
+                description: ServiceUser - optional username used for this service
+                  to register in keystone
+                type: string
+              simpleCryptoBackendKEKSecret:
+                description: Secret containing SimpleCrypto KEK
+                type: string
+              transportURLSecret:
+                type: string
+            required:
+            - containerImage
+            - databaseHostname
+            - databaseInstance
+            - rabbitMqClusterName
+            - serviceAccount
+            type: object
+          status:
+            description: BarbicanKeystoneListenerStatus defines the observed state
+              of BarbicanKeystoneListener
+            properties:
+              conditions:
+                description: Conditions
+                items:
+                  description: Condition defines an observation of a API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase.
+                      type: string
+                    severity:
+                      description: Severity provides a classification of Reason code,
+                        so the current situation is immediately understandable and
+                        could act accordingly. It is meant for situations where Status=False
+                        and it should be indicated if it is just informational, warning
+                        (next reconciliation might fix it) or an error (e.g. DB create
+                        issue and no actions to automatically resolve the issue can/should
+                        be done). For conditions where Status=Unknown or Status=True
+                        the Severity should be SeverityNone.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              databaseHostname:
+                description: Barbican Database Hostname
+                type: string
+              hash:
+                additionalProperties:
+                  type: string
+                description: Map of hashes to track e.g. job status
+                type: object
+              networkAttachments:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: NetworkAttachments status of the deployment pods
+                type: object
+              readyCount:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file ReadyCount of barbican API instances'
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/api/bases/barbican.openstack.org_barbicans.yaml
+++ b/api/bases/barbican.openstack.org_barbicans.yaml
@@ -1,0 +1,717 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.1
+  creationTimestamp: null
+  name: barbicans.barbican.openstack.org
+spec:
+  group: barbican.openstack.org
+  names:
+    kind: Barbican
+    listKind: BarbicanList
+    plural: barbicans
+    singular: barbican
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Barbican is the Schema for the barbicans API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BarbicanSpec defines the desired state of Barbican
+            properties:
+              barbicanAPI:
+                description: BarbicanAPITemplate defines the input parameters for
+                  the Barbican API service
+                properties:
+                  containerImage:
+                    description: ContainerImage - Barbican Container Image URL (will
+                      be set to environmental default if empty)
+                    type: string
+                  customServiceConfig:
+                    description: CustomServiceConfig - customize the service config
+                      using this parameter to change service defaults, or overwrite
+                      rendered information using raw OpenStack config format. The
+                      content gets added to to /etc/<service>/<service>.conf.d directory
+                      as a custom config file.
+                    type: string
+                  customServiceConfigSecrets:
+                    description: CustomServiceConfigSecrets - customize the service
+                      config using this parameter to specify Secrets that contain
+                      sensitive service config data. The content of each Secret gets
+                      added to the /etc/<service>/<service>.conf.d directory as a
+                      custom config file.
+                    items:
+                      type: string
+                    type: array
+                  defaultConfigOverwrite:
+                    additionalProperties:
+                      type: string
+                    description: 'ConfigOverwrite - interface to overwrite default
+                      config files like e.g. policy.json. But can also be used to
+                      add additional files. Those get added to the service config
+                      dir in /etc/<service> . TODO: -> implement'
+                    type: object
+                  networkAttachments:
+                    description: NetworkAttachments is a list of NetworkAttachment
+                      resource names to expose the services to the given network
+                    items:
+                      type: string
+                    type: array
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector to target subset of worker nodes running
+                      this component. Setting here overrides any global NodeSelector
+                      settings within the Barbican CR.
+                    type: object
+                  override:
+                    description: Override, provides the ability to override the generated
+                      manifest of several child resources.
+                    properties:
+                      service:
+                        additionalProperties:
+                          description: RoutedOverrideSpec - a routed service override
+                            configuration for the Service created to serve traffic
+                            to the cluster. Allows for the manifest of the created
+                            Service to be overwritten with custom configuration.
+                          properties:
+                            endpointURL:
+                              type: string
+                            metadata:
+                              description: EmbeddedLabelsAnnotations is an embedded
+                                subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.
+                                Only labels and annotations are included.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Annotations is an unstructured key
+                                    value map stored with a resource that may be set
+                                    by external tools to store and retrieve arbitrary
+                                    metadata. They are not queryable and should be
+                                    preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Map of string keys and values that
+                                    can be used to organize and categorize (scope
+                                    and select) objects. May match selectors of replication
+                                    controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                  type: object
+                              type: object
+                            spec:
+                              description: OverrideServiceSpec is a subset of the
+                                fields included in https://pkg.go.dev/k8s.io/api@v0.26.6/core/v1#ServiceSpec
+                                Limited to Type, SessionAffinity, LoadBalancerSourceRanges,
+                                ExternalName, ExternalTrafficPolicy, SessionAffinityConfig,
+                                IPFamilyPolicy, LoadBalancerClass and InternalTrafficPolicy
+                              properties:
+                                externalName:
+                                  description: externalName is the external reference
+                                    that discovery mechanisms will return as an alias
+                                    for this service (e.g. a DNS CNAME record). No
+                                    proxying will be involved.  Must be a lowercase
+                                    RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                                    and requires `type` to be "ExternalName".
+                                  type: string
+                                externalTrafficPolicy:
+                                  description: externalTrafficPolicy describes how
+                                    nodes distribute service traffic they receive
+                                    on one of the Service's "externally-facing" addresses
+                                    (NodePorts, ExternalIPs, and LoadBalancer IPs).
+                                    If set to "Local", the proxy will configure the
+                                    service in a way that assumes that external load
+                                    balancers will take care of balancing the service
+                                    traffic between nodes, and so each node will deliver
+                                    traffic only to the node-local endpoints of the
+                                    service, without masquerading the client source
+                                    IP. (Traffic mistakenly sent to a node with no
+                                    endpoints will be dropped.) The default value,
+                                    "Cluster", uses the standard behavior of routing
+                                    to all endpoints evenly (possibly modified by
+                                    topology and other features). Note that traffic
+                                    sent to an External IP or LoadBalancer IP from
+                                    within the cluster will always get "Cluster" semantics,
+                                    but clients sending to a NodePort from within
+                                    the cluster may need to take traffic policy into
+                                    account when picking a node.
+                                  type: string
+                                internalTrafficPolicy:
+                                  description: InternalTrafficPolicy describes how
+                                    nodes distribute service traffic they receive
+                                    on the ClusterIP. If set to "Local", the proxy
+                                    will assume that pods only want to talk to endpoints
+                                    of the service on the same node as the pod, dropping
+                                    the traffic if there are no local endpoints. The
+                                    default value, "Cluster", uses the standard behavior
+                                    of routing to all endpoints evenly (possibly modified
+                                    by topology and other features).
+                                  type: string
+                                ipFamilyPolicy:
+                                  description: IPFamilyPolicy represents the dual-stack-ness
+                                    requested or required by this Service. If there
+                                    is no value provided, then this field will be
+                                    set to SingleStack. Services can be "SingleStack"
+                                    (a single IP family), "PreferDualStack" (two IP
+                                    families on dual-stack configured clusters or
+                                    a single IP family on single-stack clusters),
+                                    or "RequireDualStack" (two IP families on dual-stack
+                                    configured clusters, otherwise fail). The ipFamilies
+                                    and clusterIPs fields depend on the value of this
+                                    field. This field will be wiped when updating
+                                    a service to type ExternalName.
+                                  type: string
+                                loadBalancerClass:
+                                  description: loadBalancerClass is the class of the
+                                    load balancer implementation this Service belongs
+                                    to. If specified, the value of this field must
+                                    be a label-style identifier, with an optional
+                                    prefix, e.g. "internal-vip" or "example.com/internal-vip".
+                                    Unprefixed names are reserved for end-users. This
+                                    field can only be set when the Service type is
+                                    'LoadBalancer'. If not set, the default load balancer
+                                    implementation is used, today this is typically
+                                    done through the cloud provider integration, but
+                                    should apply for any default implementation. If
+                                    set, it is assumed that a load balancer implementation
+                                    is watching for Services with a matching class.
+                                    Any default load balancer implementation (e.g.
+                                    cloud providers) should ignore Services that set
+                                    this field. This field can only be set when creating
+                                    or updating a Service to type 'LoadBalancer'.
+                                    Once set, it can not be changed. This field will
+                                    be wiped when a service is updated to a non 'LoadBalancer'
+                                    type.
+                                  type: string
+                                loadBalancerSourceRanges:
+                                  description: 'If specified and supported by the
+                                    platform, this will restrict traffic through the
+                                    cloud-provider load-balancer will be restricted
+                                    to the specified client IPs. This field will be
+                                    ignored if the cloud-provider does not support
+                                    the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+                                  items:
+                                    type: string
+                                  type: array
+                                sessionAffinity:
+                                  description: 'Supports "ClientIP" and "None". Used
+                                    to maintain session affinity. Enable client IP
+                                    based session affinity. Must be ClientIP or None.
+                                    Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                                  type: string
+                                sessionAffinityConfig:
+                                  description: sessionAffinityConfig contains the
+                                    configurations of session affinity.
+                                  properties:
+                                    clientIP:
+                                      description: clientIP contains the configurations
+                                        of Client IP based session affinity.
+                                      properties:
+                                        timeoutSeconds:
+                                          description: timeoutSeconds specifies the
+                                            seconds of ClientIP type session sticky
+                                            time. The value must be >0 && <=86400(for
+                                            1 day) if ServiceAffinity == "ClientIP".
+                                            Default value is 10800(for 3 hours).
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                                type:
+                                  description: 'type determines how the Service is
+                                    exposed. Defaults to ClusterIP. Valid options
+                                    are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                                    "ClusterIP" allocates a cluster-internal IP address
+                                    for load-balancing to endpoints. Endpoints are
+                                    determined by the selector or if that is not specified,
+                                    by manual construction of an Endpoints object
+                                    or EndpointSlice objects. If clusterIP is "None",
+                                    no virtual IP is allocated and the endpoints are
+                                    published as a set of endpoints rather than a
+                                    virtual IP. "NodePort" builds on ClusterIP and
+                                    allocates a port on every node which routes to
+                                    the same endpoints as the clusterIP. "LoadBalancer"
+                                    builds on NodePort and creates an external load-balancer
+                                    (if supported in the current cloud) which routes
+                                    to the same endpoints as the clusterIP. "ExternalName"
+                                    aliases this service to the specified externalName.
+                                    Several other fields do not apply to ExternalName
+                                    services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                                  type: string
+                              type: object
+                          type: object
+                        description: Override configuration for the Service created
+                          to serve traffic to the cluster. The key must be the endpoint
+                          type (public, internal)
+                        type: object
+                    type: object
+                  replicas:
+                    default: 1
+                    description: Replicas of Barbican API to run
+                    format: int32
+                    maximum: 32
+                    minimum: 0
+                    type: integer
+                  resources:
+                    description: Resources - Compute Resources required by this service
+                      (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: Name must match the name of one entry in
+                                pod.spec.resourceClaims of the Pod where this field
+                                is used. It makes that resource available inside a
+                                container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                required:
+                - containerImage
+                type: object
+              barbicanKeystoneListener:
+                description: BarbicanKeystoneListenerTemplate defines common Spec
+                  elements for the KeystoneListener process
+                properties:
+                  containerImage:
+                    description: ContainerImage - Barbican Container Image URL (will
+                      be set to environmental default if empty)
+                    type: string
+                  customServiceConfig:
+                    description: CustomServiceConfig - customize the service config
+                      using this parameter to change service defaults, or overwrite
+                      rendered information using raw OpenStack config format. The
+                      content gets added to to /etc/<service>/<service>.conf.d directory
+                      as a custom config file.
+                    type: string
+                  customServiceConfigSecrets:
+                    description: CustomServiceConfigSecrets - customize the service
+                      config using this parameter to specify Secrets that contain
+                      sensitive service config data. The content of each Secret gets
+                      added to the /etc/<service>/<service>.conf.d directory as a
+                      custom config file.
+                    items:
+                      type: string
+                    type: array
+                  defaultConfigOverwrite:
+                    additionalProperties:
+                      type: string
+                    description: 'ConfigOverwrite - interface to overwrite default
+                      config files like e.g. policy.json. But can also be used to
+                      add additional files. Those get added to the service config
+                      dir in /etc/<service> . TODO: -> implement'
+                    type: object
+                  networkAttachments:
+                    description: NetworkAttachments is a list of NetworkAttachment
+                      resource names to expose the services to the given network
+                    items:
+                      type: string
+                    type: array
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector to target subset of worker nodes running
+                      this component. Setting here overrides any global NodeSelector
+                      settings within the Barbican CR.
+                    type: object
+                  replicas:
+                    default: 1
+                    description: Replicas of Barbican API to run
+                    format: int32
+                    maximum: 32
+                    minimum: 0
+                    type: integer
+                  resources:
+                    description: Resources - Compute Resources required by this service
+                      (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: Name must match the name of one entry in
+                                pod.spec.resourceClaims of the Pod where this field
+                                is used. It makes that resource available inside a
+                                container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                required:
+                - containerImage
+                type: object
+              barbicanWorker:
+                description: BarbicanWorkerTemplate defines common Spec elements for
+                  the Worker process
+                properties:
+                  containerImage:
+                    description: ContainerImage - Barbican Container Image URL (will
+                      be set to environmental default if empty)
+                    type: string
+                  customServiceConfig:
+                    description: CustomServiceConfig - customize the service config
+                      using this parameter to change service defaults, or overwrite
+                      rendered information using raw OpenStack config format. The
+                      content gets added to to /etc/<service>/<service>.conf.d directory
+                      as a custom config file.
+                    type: string
+                  customServiceConfigSecrets:
+                    description: CustomServiceConfigSecrets - customize the service
+                      config using this parameter to specify Secrets that contain
+                      sensitive service config data. The content of each Secret gets
+                      added to the /etc/<service>/<service>.conf.d directory as a
+                      custom config file.
+                    items:
+                      type: string
+                    type: array
+                  defaultConfigOverwrite:
+                    additionalProperties:
+                      type: string
+                    description: 'ConfigOverwrite - interface to overwrite default
+                      config files like e.g. policy.json. But can also be used to
+                      add additional files. Those get added to the service config
+                      dir in /etc/<service> . TODO: -> implement'
+                    type: object
+                  networkAttachments:
+                    description: NetworkAttachments is a list of NetworkAttachment
+                      resource names to expose the services to the given network
+                    items:
+                      type: string
+                    type: array
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector to target subset of worker nodes running
+                      this component. Setting here overrides any global NodeSelector
+                      settings within the Barbican CR.
+                    type: object
+                  replicas:
+                    default: 1
+                    description: Replicas of Barbican API to run
+                    format: int32
+                    maximum: 32
+                    minimum: 0
+                    type: integer
+                  resources:
+                    description: Resources - Compute Resources required by this service
+                      (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: Name must match the name of one entry in
+                                pod.spec.resourceClaims of the Pod where this field
+                                is used. It makes that resource available inside a
+                                container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                required:
+                - containerImage
+                type: object
+              customServiceConfig:
+                description: CustomServiceConfig - customize the service config using
+                  this parameter to change service defaults, or overwrite rendered
+                  information using raw OpenStack config format. The content gets
+                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
+                  file.
+                type: string
+              databaseInstance:
+                description: 'MariaDB instance name TODO(dmendiza): Is this comment
+                  right? Right now required by the maridb-operator to get the credentials
+                  from the instance to create the DB Might not be required in future'
+                type: string
+              databaseUser:
+                default: barbican
+                description: DatabaseUser - optional username used for barbican DB,
+                  defaults to barbican
+                type: string
+              debug:
+                description: 'Debug - enable debug for different deploy stages. If
+                  an init container is used, it runs and the actual action pod gets
+                  started with sleep infinity TODO(dmendiza): Do we need this?'
+                properties:
+                  dbInitContainer:
+                    default: false
+                    description: dbInitContainer enable debug (waits until /tmp/stop-init-container
+                      disappears)
+                    type: boolean
+                  dbSync:
+                    default: false
+                    description: dbSync enable debug
+                    type: boolean
+                  initContainer:
+                    default: false
+                    description: initContainer enable debug (waits until /tmp/stop-init-container
+                      disappears)
+                    type: boolean
+                  service:
+                    default: false
+                    description: Service enable debug
+                    type: boolean
+                type: object
+              defaultConfigOverwrite:
+                additionalProperties:
+                  type: string
+                description: 'ConfigOverwrite - interface to overwrite default config
+                  files like e.g. logging.conf or policy.json. But can also be used
+                  to add additional files. Those get added to the service config dir
+                  in /etc/<service> . TODO(dmendiza): -> implement'
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector to target subset of worker nodes running
+                  this component. Setting here overrides any global NodeSelector settings
+                  within the Barbican CR.
+                type: object
+              passwordSelectors:
+                default:
+                  database: BarbicanDatabasePassword
+                  service: BarbicanPassword
+                description: 'TODO(dmendiza): Maybe we''ll add SimpleCrypto key here?
+                  PasswordSelectors - Selectors to identify the DB and ServiceUser
+                  password from the Secret'
+                properties:
+                  database:
+                    default: BarbicanDatabasePassword
+                    description: Database - Selector to get the barbican database
+                      user password from the Secret
+                    type: string
+                  service:
+                    default: BarbicanPassword
+                    description: Service - Selector to get the barbican service user
+                      password from the Secret
+                    type: string
+                type: object
+              preserveJobs:
+                default: false
+                description: PreserveJobs - do not delete jobs after they finished
+                  e.g. to check logs
+                type: boolean
+              rabbitMqClusterName:
+                default: rabbitmq
+                description: RabbitMQ instance name Needed to request a transportURL
+                  that is created and used in Barbican
+                type: string
+              secret:
+                description: Secret containing all passwords / keys needed
+                type: string
+              serviceAccount:
+                description: ServiceAccount - service account name used internally
+                  to provide Barbican services the default SA name
+                type: string
+              serviceUser:
+                default: barbican
+                description: ServiceUser - optional username used for this service
+                  to register in keystone
+                type: string
+              simpleCryptoBackendKEKSecret:
+                description: Secret containing SimpleCrypto KEK
+                type: string
+            required:
+            - barbicanAPI
+            - barbicanKeystoneListener
+            - barbicanWorker
+            - databaseInstance
+            - rabbitMqClusterName
+            - serviceAccount
+            type: object
+          status:
+            description: BarbicanStatus defines the observed state of Barbican
+            properties:
+              barbicanAPIReadyCount:
+                description: ReadyCount of Barbican API instances
+                format: int32
+                type: integer
+              barbicanKeystoneListenerReadyCount:
+                description: ReadyCount of Barbican KeystoneListener instances
+                format: int32
+                type: integer
+              barbicanWorkerReadyCount:
+                description: ReadyCount of Barbican Worker instances
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions
+                items:
+                  description: Condition defines an observation of a API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase.
+                      type: string
+                    severity:
+                      description: Severity provides a classification of Reason code,
+                        so the current situation is immediately understandable and
+                        could act accordingly. It is meant for situations where Status=False
+                        and it should be indicated if it is just informational, warning
+                        (next reconciliation might fix it) or an error (e.g. DB create
+                        issue and no actions to automatically resolve the issue can/should
+                        be done). For conditions where Status=Unknown or Status=True
+                        the Severity should be SeverityNone.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              databaseHostname:
+                description: Barbican Database Hostname
+                type: string
+              hash:
+                additionalProperties:
+                  type: string
+                description: Map of hashes to track e.g. job status
+                type: object
+              serviceID:
+                description: ServiceID
+                type: string
+              transportURLSecret:
+                description: TransportURLSecret - Secret containing RabbitMQ transportURL
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/api/bases/barbican.openstack.org_barbicanworkers.yaml
+++ b/api/bases/barbican.openstack.org_barbicanworkers.yaml
@@ -1,0 +1,289 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.1
+  creationTimestamp: null
+  name: barbicanworkers.barbican.openstack.org
+spec:
+  group: barbican.openstack.org
+  names:
+    kind: BarbicanWorker
+    listKind: BarbicanWorkerList
+    plural: barbicanworkers
+    singular: barbicanworker
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: BarbicanWorker is the Schema for the barbicanworkers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BarbicanWorkerSpec defines the desired state of BarbicanWorker
+            properties:
+              containerImage:
+                description: ContainerImage - Barbican Container Image URL (will be
+                  set to environmental default if empty)
+                type: string
+              customServiceConfig:
+                description: CustomServiceConfig - customize the service config using
+                  this parameter to change service defaults, or overwrite rendered
+                  information using raw OpenStack config format. The content gets
+                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
+                  file.
+                type: string
+              customServiceConfigSecrets:
+                description: CustomServiceConfigSecrets - customize the service config
+                  using this parameter to specify Secrets that contain sensitive service
+                  config data. The content of each Secret gets added to the /etc/<service>/<service>.conf.d
+                  directory as a custom config file.
+                items:
+                  type: string
+                type: array
+              databaseHostname:
+                type: string
+              databaseInstance:
+                description: 'MariaDB instance name TODO(dmendiza): Is this comment
+                  right? Right now required by the maridb-operator to get the credentials
+                  from the instance to create the DB Might not be required in future'
+                type: string
+              databaseUser:
+                default: barbican
+                description: DatabaseUser - optional username used for barbican DB,
+                  defaults to barbican
+                type: string
+              debug:
+                description: 'Debug - enable debug for different deploy stages. If
+                  an init container is used, it runs and the actual action pod gets
+                  started with sleep infinity TODO(dmendiza): Do we need this?'
+                properties:
+                  dbInitContainer:
+                    default: false
+                    description: dbInitContainer enable debug (waits until /tmp/stop-init-container
+                      disappears)
+                    type: boolean
+                  dbSync:
+                    default: false
+                    description: dbSync enable debug
+                    type: boolean
+                  initContainer:
+                    default: false
+                    description: initContainer enable debug (waits until /tmp/stop-init-container
+                      disappears)
+                    type: boolean
+                  service:
+                    default: false
+                    description: Service enable debug
+                    type: boolean
+                type: object
+              defaultConfigOverwrite:
+                additionalProperties:
+                  type: string
+                description: 'ConfigOverwrite - interface to overwrite default config
+                  files like e.g. policy.json. But can also be used to add additional
+                  files. Those get added to the service config dir in /etc/<service>
+                  . TODO: -> implement'
+                type: object
+              networkAttachments:
+                description: NetworkAttachments is a list of NetworkAttachment resource
+                  names to expose the services to the given network
+                items:
+                  type: string
+                type: array
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector to target subset of worker nodes running
+                  this component. Setting here overrides any global NodeSelector settings
+                  within the Barbican CR.
+                type: object
+              passwordSelectors:
+                default:
+                  database: BarbicanDatabasePassword
+                  service: BarbicanPassword
+                description: 'TODO(dmendiza): Maybe we''ll add SimpleCrypto key here?
+                  PasswordSelectors - Selectors to identify the DB and ServiceUser
+                  password from the Secret'
+                properties:
+                  database:
+                    default: BarbicanDatabasePassword
+                    description: Database - Selector to get the barbican database
+                      user password from the Secret
+                    type: string
+                  service:
+                    default: BarbicanPassword
+                    description: Service - Selector to get the barbican service user
+                      password from the Secret
+                    type: string
+                type: object
+              rabbitMqClusterName:
+                default: rabbitmq
+                description: RabbitMQ instance name Needed to request a transportURL
+                  that is created and used in Barbican
+                type: string
+              replicas:
+                default: 1
+                description: Replicas of Barbican API to run
+                format: int32
+                maximum: 32
+                minimum: 0
+                type: integer
+              resources:
+                description: Resources - Compute Resources required by this service
+                  (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                properties:
+                  claims:
+                    description: "Claims lists the names of resources, defined in
+                      spec.resourceClaims, that are used by this container. \n This
+                      is an alpha field and requires enabling the DynamicResourceAllocation
+                      feature gate. \n This field is immutable. It can only be set
+                      for containers."
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: Name must match the name of one entry in pod.spec.resourceClaims
+                            of the Pod where this field is used. It makes that resource
+                            available inside a container.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              secret:
+                description: Secret containing all passwords / keys needed
+                type: string
+              serviceAccount:
+                description: ServiceAccount - service account name used internally
+                  to provide Barbican services the default SA name
+                type: string
+              serviceUser:
+                default: barbican
+                description: ServiceUser - optional username used for this service
+                  to register in keystone
+                type: string
+              simpleCryptoBackendKEKSecret:
+                description: Secret containing SimpleCrypto KEK
+                type: string
+              transportURLSecret:
+                type: string
+            required:
+            - containerImage
+            - databaseHostname
+            - databaseInstance
+            - rabbitMqClusterName
+            - serviceAccount
+            type: object
+          status:
+            description: BarbicanWorkerStatus defines the observed state of BarbicanWorker
+            properties:
+              conditions:
+                description: Conditions
+                items:
+                  description: Condition defines an observation of a API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase.
+                      type: string
+                    severity:
+                      description: Severity provides a classification of Reason code,
+                        so the current situation is immediately understandable and
+                        could act accordingly. It is meant for situations where Status=False
+                        and it should be indicated if it is just informational, warning
+                        (next reconciliation might fix it) or an error (e.g. DB create
+                        issue and no actions to automatically resolve the issue can/should
+                        be done). For conditions where Status=Unknown or Status=True
+                        the Severity should be SeverityNone.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              databaseHostname:
+                description: Barbican Database Hostname
+                type: string
+              hash:
+                additionalProperties:
+                  type: string
+                description: Map of hashes to track e.g. job status
+                type: object
+              networkAttachments:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: NetworkAttachments status of the deployment pods
+                type: object
+              readyCount:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file ReadyCount of barbican API instances'
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
This is something that has changed in the Makefile since we started. Importantly, the functional tests in openstack-operator and possibly other places expect this to be there so that the crds can be loaded.