### PR TITLE
Support disconnected network environments

### DIFF
--- a/.prow_ci.env
+++ b/.prow_ci.env
@@ -1,0 +1,1 @@
+export USE_IMAGE_DIGESTS=true

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 endif
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+DEFAULT_IMG ?= quay.io/openstack-k8s-operators/barbican-operator:latest
+IMG ?= $(DEFAULT_IMG)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.26.0
 

--- a/api/v1beta1/barbican_types.go
+++ b/api/v1beta1/barbican_types.go
@@ -150,9 +150,9 @@ func init() {
 func SetupDefaults() {
 	// Acquire environmental defaults and initialize Barbican defaults with them
 	barbicanDefaults := BarbicanDefaults{
-		APIContainerImageURL:              util.GetEnvVar("BARBICAN_API_IMAGE_URL_DEFAULT", BarbicanAPIContainerImage),
-		WorkerContainerImageURL:           util.GetEnvVar("BARBICAN_WORKER_IMAGE_URL_DEFAULT", BarbicanWorkerContainerImage),
-		KeystoneListenerContainerImageURL: util.GetEnvVar("BARBICAN_KEYSTONE_LISTENER_IMAGE_URL_DEFAULT", BarbicanKeystoneListenerContainerImage),
+		APIContainerImageURL:              util.GetEnvVar("RELATED_IMAGE_BARBICAN_API_IMAGE_URL_DEFAULT", BarbicanAPIContainerImage),
+		WorkerContainerImageURL:           util.GetEnvVar("RELATED_IMAGE_BARBICAN_WORKER_IMAGE_URL_DEFAULT", BarbicanWorkerContainerImage),
+		KeystoneListenerContainerImageURL: util.GetEnvVar("RELATED_IMAGE_BARBICAN_KEYSTONE_LISTENER_IMAGE_URL_DEFAULT", BarbicanKeystoneListenerContainerImage),
 	}
 
 	SetupBarbicanDefaults(barbicanDefaults)

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -11,10 +11,10 @@ spec:
       containers:
       - name: manager
         env:
-        - name: BARBICAN_API_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_BARBICAN_API_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-barbican-api:current-podified
-        - name: BARBICAN_WORKER_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_BARBICAN_WORKER_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-barbican-worker:current-podified
-        - name: BARBICAN_KEYSTONE_LISTENER_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_BARBICAN_KEYSTONE_LISTENER_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-barbican-keystone-listener:current-podified
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
+  newName: quay.io/openstack-k8s-operators/barbican-operator
   newTag: latest

--- a/config/manifests/bases/barbican-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/barbican-operator.clusterserviceversion.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    operatorframework.io/suggested-namespace: openstack
     features.operators.openshift.io/disconnected: "true"
     operators.openshift.io/infrastructure-features: '["disconnected"]'
+    operators.operatorframework.io/operator-type: non-standalone
   name: barbican-operator.v0.0.0
   namespace: placeholder
 spec:

--- a/config/manifests/bases/barbican-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/barbican-operator.clusterserviceversion.yaml
@@ -5,6 +5,8 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     operatorframework.io/suggested-namespace: openstack
+    features.operators.openshift.io/disconnected: "true"
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
   name: barbican-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
This PR adds support for installing the operator in disconnected network environments. To build with image-digests set USE_IMAGE_DIGESTS=true before running make bundle.

For Prow jobs we are enabling this via .prow-ci.env

(NOTE: this currently requires a secure registry)