### PR TITLE
Make Secure RBAC configurable

### DIFF
--- a/api/bases/barbican.openstack.org_barbicanapis.yaml
+++ b/api/bases/barbican.openstack.org_barbicanapis.yaml
@@ -99,6 +99,11 @@ spec:
                   files. Those get added to the service config dir in /etc/<service>
                   . TODO: -> implement'
                 type: object
+              enableSecureRBAC:
+                default: true
+                description: EnableSecureRBAC - Enable Consistent and Secure RBAC
+                  policies
+                type: boolean
               networkAttachments:
                 description: NetworkAttachments is a list of NetworkAttachment resource
                   names to expose the services to the given network

--- a/api/bases/barbican.openstack.org_barbicans.yaml
+++ b/api/bases/barbican.openstack.org_barbicans.yaml
@@ -67,6 +67,11 @@ spec:
                       add additional files. Those get added to the service config
                       dir in /etc/<service> . TODO: -> implement'
                     type: object
+                  enableSecureRBAC:
+                    default: true
+                    description: EnableSecureRBAC - Enable Consistent and Secure RBAC
+                      policies
+                    type: boolean
                   networkAttachments:
                     description: NetworkAttachments is a list of NetworkAttachment
                       resource names to expose the services to the given network

--- a/api/v1beta1/barbicanapi_types.go
+++ b/api/v1beta1/barbicanapi_types.go
@@ -27,6 +27,11 @@ type BarbicanAPITemplate struct {
 	// Common input parameters for the Barbican API service
 	BarbicanComponentTemplate `json:",inline"`
 
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=true
+	// EnableSecureRBAC - Enable Consistent and Secure RBAC policies
+	EnableSecureRBAC bool `json:"enableSecureRBAC"`
+
 	// Override, provides the ability to override the generated manifest of several child resources.
 	Override APIOverrideSpec `json:"override,omitempty"`
 }

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -5,6 +5,7 @@ import (
 )
 
 // BarbicanTemplate defines common Spec elements for all Barbican components
+// including the top level CR
 type BarbicanTemplate struct {
 
 	// +kubebuilder:validation:Optional
@@ -61,7 +62,7 @@ type BarbicanTemplate struct {
 	ServiceAccount string `json:"serviceAccount"`
 }
 
-// BarbicanComponentTemplate - Variables used by every component of Barbican
+// BarbicanComponentTemplate - Variables used by every sub-component of Barbican
 // (e.g. API, Worker, Listener)
 type BarbicanComponentTemplate struct {
 

--- a/config/crd/bases/barbican.openstack.org_barbicanapis.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicanapis.yaml
@@ -99,6 +99,11 @@ spec:
                   files. Those get added to the service config dir in /etc/<service>
                   . TODO: -> implement'
                 type: object
+              enableSecureRBAC:
+                default: true
+                description: EnableSecureRBAC - Enable Consistent and Secure RBAC
+                  policies
+                type: boolean
               networkAttachments:
                 description: NetworkAttachments is a list of NetworkAttachment resource
                   names to expose the services to the given network

--- a/config/crd/bases/barbican.openstack.org_barbicans.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicans.yaml
@@ -67,6 +67,11 @@ spec:
                       add additional files. Those get added to the service config
                       dir in /etc/<service> . TODO: -> implement'
                     type: object
+                  enableSecureRBAC:
+                    default: true
+                    description: EnableSecureRBAC - Enable Consistent and Secure RBAC
+                      policies
+                    type: boolean
                   networkAttachments:
                     description: NetworkAttachments is a list of NetworkAttachment
                       resource names to expose the services to the given network

--- a/controllers/barbican_controller.go
+++ b/controllers/barbican_controller.go
@@ -539,12 +539,13 @@ func (r *BarbicanReconciler) generateServiceConfig(
 			instance.Status.DatabaseHostname,
 			barbican.DatabaseName,
 		),
-		"KeystoneAuthURL": keystoneInternalURL,
-		"ServicePassword": string(ospSecret.Data[instance.Spec.PasswordSelectors.Service]),
-		"ServiceUser":     instance.Spec.ServiceUser,
-		"ServiceURL":      "TODO",
-		"TransportURL":    string(transportURLSecret.Data["transport_url"]),
-		"LogFile":         fmt.Sprintf("%s%s.log", barbican.BarbicanLogPath, instance.Name),
+		"KeystoneAuthURL":  keystoneInternalURL,
+		"ServicePassword":  string(ospSecret.Data[instance.Spec.PasswordSelectors.Service]),
+		"ServiceUser":      instance.Spec.ServiceUser,
+		"ServiceURL":       "TODO",
+		"TransportURL":     string(transportURLSecret.Data["transport_url"]),
+		"LogFile":          fmt.Sprintf("%s%s.log", barbican.BarbicanLogPath, instance.Name),
+		"EnableSecureRBAC": instance.Spec.BarbicanAPI.EnableSecureRBAC,
 	}
 
 	return GenerateConfigsGeneric(ctx, h, instance, envVars, templateParameters, customData, labels, false)

--- a/controllers/barbicanapi_controller.go
+++ b/controllers/barbicanapi_controller.go
@@ -279,12 +279,13 @@ func (r *BarbicanAPIReconciler) generateServiceConfigs(
 			instance.Spec.DatabaseHostname,
 			barbican.DatabaseName,
 		),
-		"KeystoneAuthURL": keystoneInternalURL,
-		"ServicePassword": string(ospSecret.Data[instance.Spec.PasswordSelectors.Service]),
-		"ServiceUser":     instance.Spec.ServiceUser,
-		"ServiceURL":      "https://barbican.openstack.svc:9311",
-		"TransportURL":    string(transportURLSecret.Data["transport_url"]),
-		"LogFile":         fmt.Sprintf("%s%s.log", barbican.BarbicanLogPath, instance.Name),
+		"KeystoneAuthURL":  keystoneInternalURL,
+		"ServicePassword":  string(ospSecret.Data[instance.Spec.PasswordSelectors.Service]),
+		"ServiceUser":      instance.Spec.ServiceUser,
+		"ServiceURL":       "https://barbican.openstack.svc:9311",
+		"TransportURL":     string(transportURLSecret.Data["transport_url"]),
+		"LogFile":          fmt.Sprintf("%s%s.log", barbican.BarbicanLogPath, instance.Name),
+		"EnableSecureRBAC": instance.Spec.EnableSecureRBAC,
 	}
 
 	return GenerateConfigsGeneric(ctx, h, instance, envVars, templateParameters, customData, labels, false)

--- a/templates/barbican/config/00-default.conf
+++ b/templates/barbican/config/00-default.conf
@@ -28,8 +28,8 @@ topic = barbican_notifications
 driver=messagingv2
 
 [oslo_policy]
-enforce_scope = true
-enforce_new_defaults = true
+enforce_scope = {{ .EnableSecureRBAC }}
+enforce_new_defaults = {{ .EnableSecureRBAC }}
 
 [queue]
 enable = true


### PR DESCRIPTION
This patch adds a new field to the BarbicanAPI spec to configure "Consistent and Secure RBAC" [1].  The API configuration template was modified to use the value in this field instead of being hard-coded to always be on.

Jira: OSPRH-2129

[1] https://governance.openstack.org/tc/goals/selected/consistent-and-secure-rbac.html