### PR TITLE
Add missing net-attach-def permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -192,6 +192,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - network-attachment-definitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - keystone.openstack.org
   resources:
   - keystoneapis

--- a/controllers/barbican_controller.go
+++ b/controllers/barbican_controller.go
@@ -89,6 +89,8 @@ func (r *BarbicanReconciler) GetLogger(ctx context.Context) logr.Logger {
 //+kubebuilder:rbac:groups=rabbitmq.openstack.org,resources=transporturls,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete;
 //+kubebuilder:rbac:groups=mariadb.openstack.org,resources=mariadbdatabases,verbs=get;list;watch;create;update;patch;delete;
+//+kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch
+
 // service account, role, rolebinding
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update


### PR DESCRIPTION
This is needed in case the the user includes any `networkAttachments` in the various CRs.  Otherwise we see this:

```
E1218 13:13:53.990846       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.26.9/tools/cache/reflector.go:169: Failed to watch *v1.NetworkAttachmentDefinition: failed to list *v1.NetworkAttachmentDefinition: network-attachment-definitions.k8s.cni.cncf.io is forbidden: User "system:serviceaccount:openstack-operators:barbican-operator-controller-manager" cannot list resource "network-attachment-definitions" in API group "k8s.cni.cncf.io" at the cluster scope
```