### PR TITLE
Fix 'EnableSecureRBAC' templating

### DIFF
--- a/templates/barbican/config/00-default.conf
+++ b/templates/barbican/config/00-default.conf
@@ -27,9 +27,11 @@ topic = barbican_notifications
 [oslo_messaging_notifications]
 driver=messagingv2
 
+{{ if (index . "EnableSecureRBAC") }}
 [oslo_policy]
 enforce_scope = {{ .EnableSecureRBAC }}
 enforce_new_defaults = {{ .EnableSecureRBAC }}
+{{ end }}
 
 [queue]
 enable = true


### PR DESCRIPTION
Without this, `Barbican` deployment fails with...

```
    - lastTransitionTime: "2024-01-02T17:33:48Z"
      message: 'Service config create error occurred template: tmp:31:19: executing
        "tmp" at <.EnableSecureRBAC>: map has no entry for key "EnableSecureRBAC"'
      reason: Error
      severity: Warning
      status: "False"
      type: Ready
```

...for certain sub-types (worker, Keystone listener, etc) that do not set the value in their respective reconcile loop.