### PR TITLE
Add ci-operator base image config for Prow jobs

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: tools
+  namespace: openstack-k8s-operators
+  tag: ci-build-root-golang-1.19-sdk-1.31


### PR DESCRIPTION
This config file is used by Prow to define the base image for jobs. It is a config per project.