### PR TITLE
Use Simple Crypto KEK from Secret

### DIFF
--- a/controllers/barbicanapi_controller.go
+++ b/controllers/barbicanapi_controller.go
@@ -285,6 +285,7 @@ func (r *BarbicanAPIReconciler) generateServiceConfigs(
 		"ServiceURL":       "https://barbican.openstack.svc:9311",
 		"TransportURL":     string(transportURLSecret.Data["transport_url"]),
 		"LogFile":          fmt.Sprintf("%s%s.log", barbican.BarbicanLogPath, instance.Name),
+		"SimpleCryptoKEK":  string(ospSecret.Data["BarbicanSimpleCryptoKEK"]),
 		"EnableSecureRBAC": instance.Spec.EnableSecureRBAC,
 	}
 

--- a/controllers/barbicanworker_controller.go
+++ b/controllers/barbicanworker_controller.go
@@ -248,8 +248,9 @@ func (r *BarbicanWorkerReconciler) generateServiceConfigs(
 			instance.Spec.DatabaseHostname,
 			barbican.DatabaseName,
 		),
-		"TransportURL": string(transportURLSecret.Data["transport_url"]),
-		"LogFile":      fmt.Sprintf("%s%s.log", barbican.BarbicanLogPath, instance.Name),
+		"TransportURL":    string(transportURLSecret.Data["transport_url"]),
+		"LogFile":         fmt.Sprintf("%s%s.log", barbican.BarbicanLogPath, instance.Name),
+		"SimpleCryptoKEK": string(ospSecret.Data["BarbicanSimpleCryptoKEK"]),
 	}
 
 	return GenerateConfigsGeneric(ctx, h, instance, envVars, templateParameters, customData, labels, false)

--- a/templates/barbican/config/00-default.conf
+++ b/templates/barbican/config/00-default.conf
@@ -47,4 +47,6 @@ global_default = true
 
 [simple_crypto_plugin]
 plugin_name = Software Only Crypto
-kek = dGhpcnR5X3R3b19ieXRlX2tleWJsYWhibGFoYmxhaGg=
+{{ if (index . "SimpleCryptoKEK") }}
+kek = {{ .SimpleCryptoKEK }}
+{{ end }}


### PR DESCRIPTION
This patch changes the configuration template to use a KEK provided in the OSP secret instead of a hard-coded one.