### PR TITLE
Fix intermittent connection refused

### DIFF
--- a/controllers/barbicanapi_controller.go
+++ b/controllers/barbicanapi_controller.go
@@ -574,7 +574,8 @@ func (r *BarbicanAPIReconciler) reconcileNormal(ctx context.Context, instance *b
 
 	Log.Info(fmt.Sprintf("[API] Getting service labels '%s'", instance.Name))
 	serviceLabels := map[string]string{
-		common.AppSelector: fmt.Sprintf(barbican.ServiceName),
+		common.AppSelector:       fmt.Sprintf(barbican.ServiceName),
+		common.ComponentSelector: barbican.ComponentAPI,
 	}
 
 	Log.Info(fmt.Sprintf("[API] Getting networks '%s'", instance.Name))

--- a/controllers/barbicankeystonelistener_controller.go
+++ b/controllers/barbicankeystonelistener_controller.go
@@ -511,7 +511,8 @@ func (r *BarbicanKeystoneListenerReconciler) reconcileNormal(ctx context.Context
 
 	Log.Info(fmt.Sprintf("[KeystoneListener] Getting service labels '%s'", instance.Name))
 	serviceLabels := map[string]string{
-		common.AppSelector: fmt.Sprintf(barbican.ServiceName),
+		common.AppSelector:       fmt.Sprintf(barbican.ServiceName),
+		common.ComponentSelector: barbican.ComponentKeystoneListener,
 	}
 
 	Log.Info(fmt.Sprintf("[KeystoneListener] Getting networks '%s'", instance.Name))

--- a/controllers/barbicanworker_controller.go
+++ b/controllers/barbicanworker_controller.go
@@ -370,7 +370,8 @@ func (r *BarbicanWorkerReconciler) reconcileNormal(ctx context.Context, instance
 
 	Log.Info(fmt.Sprintf("[Worker] Getting service labels '%s'", instance.Name))
 	serviceLabels := map[string]string{
-		common.AppSelector: fmt.Sprintf(barbican.ServiceName),
+		common.AppSelector:       fmt.Sprintf(barbican.ServiceName),
+		common.ComponentSelector: barbican.ComponentWorker,
 	}
 
 	Log.Info(fmt.Sprintf("[Worker] Getting networks '%s'", instance.Name))

--- a/pkg/barbican/const.go
+++ b/pkg/barbican/const.go
@@ -5,6 +5,12 @@ import "github.com/openstack-k8s-operators/lib-common/modules/storage"
 const (
 	// ServiceName -
 	ServiceName = "barbican"
+	// ComponentAPI -
+	ComponentAPI = "barbican-api"
+	// ComponentKeystoneListener -
+	ComponentKeystoneListener = "keystone-listener"
+	// ComponentWorker -
+	ComponentWorker = "barbican-worker"
 	// ServiceType -
 	ServiceType = "key-manager"
 	// DatabaseName -


### PR DESCRIPTION
During the test of `Glance` image sign that rely on `Barbican` to store secrets, we’d see `Connection refused` errors on about 60% of the calls made to the service. This let the image signing fail most of the times.
In addition, simply running `curl` against the `barbican-internal` endpoint shows this issue, because it fails more than **half** of the times with a `connection refused` error on 9311.
However, if we point directly to the `Pod` (bypassing the k8s `Service`), we can see that this problem doesn't occur, and we're able to always reach the `Barbican` service and successfully sign the `Glance` images.
The root cause of this issue is the k8s `Service` sending traffic to the `BarbicanAPI`, as well as `keystoneListener` and `BarbicanWorker`: these two services are not listening on `9311`, and this result in a connection refused on that port.
The `BarbicanAPI` service should be built with a selector that is able to forward the traffic to `barbicanAPI` only, and this patch improves the way labels are used to achieve this goal, similarly to what we did in `Cinder`, `Glance` and `Manila`.
With this patch we no longer see any issue when we try to reach the `barbicanAPI` component and we're able to retrieve the secrets and sign images.

Fixes: [OSPRH-3420](https://issues.redhat.com//browse/OSPRH-3420)