### PR TITLE
Move -log sidecar container to dumb-init

### DIFF
--- a/pkg/barbicanapi/deployment.go
+++ b/pkg/barbicanapi/deployment.go
@@ -111,9 +111,16 @@ func Deployment(
 						{
 							Name: instance.Name + "-log",
 							Command: []string{
-								"/bin/bash",
+								"/usr/bin/dumb-init",
 							},
-							Args:  []string{"-c", "tail -n+1 -F " + barbican.BarbicanLogPath + instance.Name + ".log"},
+							Args: []string{
+								"--single-child",
+								"--",
+								"/usr/bin/tail",
+								"-n+1",
+								"-F",
+								barbican.BarbicanLogPath + instance.Name + ".log",
+							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: &runAsUser,

--- a/pkg/barbicankeystonelistener/deployment.go
+++ b/pkg/barbicankeystonelistener/deployment.go
@@ -84,9 +84,16 @@ func Deployment(
 						{
 							Name: instance.Name + "-log",
 							Command: []string{
-								"/bin/bash",
+								"/usr/bin/dumb-init",
 							},
-							Args:  []string{"-c", "tail -n+1 -F " + barbican.BarbicanLogPath + instance.Name + ".log"},
+							Args: []string{
+								"--single-child",
+								"--",
+								"/usr/bin/tail",
+								"-n+1",
+								"-F",
+								barbican.BarbicanLogPath + instance.Name + ".log",
+							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: &runAsUser,

--- a/pkg/barbicanworker/deployment.go
+++ b/pkg/barbicanworker/deployment.go
@@ -113,9 +113,16 @@ func Deployment(
 						{
 							Name: instance.Name + "-log",
 							Command: []string{
-								"/bin/bash",
+								"/usr/bin/dumb-init",
 							},
-							Args:  []string{"-c", "tail -n+1 -F " + barbican.BarbicanLogPath + instance.Name + ".log"},
+							Args: []string{
+								"--single-child",
+								"--",
+								"/usr/bin/tail",
+								"-n+1",
+								"-F",
+								barbican.BarbicanLogPath + instance.Name + ".log",
+							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: &runAsUser,


### PR DESCRIPTION
As noticed in other operators (and already fixed), the -log sidecar ignores `SIGTERM` on delete.
This patch moves the barbican-operator to the `dumb-init` usage to make sure the `SIGTERM` is handled properly by the sidecar.

Fixes: [OSPRH-3283](https://issues.redhat.com/browse/OSPRH-3283)