### PR TITLE
Add options to separate KEK from osp-secret

### DIFF
--- a/api/bases/barbican.openstack.org_barbicanapis.yaml
+++ b/api/bases/barbican.openstack.org_barbicanapis.yaml
@@ -271,9 +271,9 @@ spec:
                 default:
                   database: BarbicanDatabasePassword
                   service: BarbicanPassword
-                description: 'TODO(dmendiza): Maybe we''ll add SimpleCrypto key here?
-                  PasswordSelectors - Selectors to identify the DB and ServiceUser
-                  password from the Secret'
+                  simplecryptokek: BarbicanSimpleCryptoKEK
+                description: PasswordSelectors - Selectors to identify the DB and
+                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: BarbicanDatabasePassword
@@ -284,6 +284,9 @@ spec:
                     default: BarbicanPassword
                     description: Service - Selector to get the barbican service user
                       password from the Secret
+                    type: string
+                  simplecryptokek:
+                    default: SimpleCryptoKEK
                     type: string
                 type: object
               rabbitMqClusterName:
@@ -348,6 +351,7 @@ spec:
                     type: object
                 type: object
               secret:
+                default: osp-secret
                 description: Secret containing all passwords / keys needed
                 type: string
               serviceAccount:
@@ -359,8 +363,10 @@ spec:
                 description: ServiceUser - optional username used for this service
                   to register in keystone
                 type: string
-              simpleCryptoBackendKEKSecret:
-                description: Secret containing SimpleCrypto KEK
+              simpleCryptoBackendSecret:
+                default: osp-secret
+                description: Secret containing the Key Encryption Key (KEK) used for
+                  the Simple Crypto backend
                 type: string
               tls:
                 description: TLS - Parameters related to the TLS

--- a/api/bases/barbican.openstack.org_barbicankeystonelisteners.yaml
+++ b/api/bases/barbican.openstack.org_barbicankeystonelisteners.yaml
@@ -93,9 +93,9 @@ spec:
                 default:
                   database: BarbicanDatabasePassword
                   service: BarbicanPassword
-                description: 'TODO(dmendiza): Maybe we''ll add SimpleCrypto key here?
-                  PasswordSelectors - Selectors to identify the DB and ServiceUser
-                  password from the Secret'
+                  simplecryptokek: BarbicanSimpleCryptoKEK
+                description: PasswordSelectors - Selectors to identify the DB and
+                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: BarbicanDatabasePassword
@@ -106,6 +106,9 @@ spec:
                     default: BarbicanPassword
                     description: Service - Selector to get the barbican service user
                       password from the Secret
+                    type: string
+                  simplecryptokek:
+                    default: SimpleCryptoKEK
                     type: string
                 type: object
               rabbitMqClusterName:
@@ -170,6 +173,7 @@ spec:
                     type: object
                 type: object
               secret:
+                default: osp-secret
                 description: Secret containing all passwords / keys needed
                 type: string
               serviceAccount:
@@ -181,8 +185,10 @@ spec:
                 description: ServiceUser - optional username used for this service
                   to register in keystone
                 type: string
-              simpleCryptoBackendKEKSecret:
-                description: Secret containing SimpleCrypto KEK
+              simpleCryptoBackendSecret:
+                default: osp-secret
+                description: Secret containing the Key Encryption Key (KEK) used for
+                  the Simple Crypto backend
                 type: string
               tls:
                 description: TLS - Parameters related to the TLS

--- a/api/bases/barbican.openstack.org_barbicans.yaml
+++ b/api/bases/barbican.openstack.org_barbicans.yaml
@@ -603,9 +603,9 @@ spec:
                 default:
                   database: BarbicanDatabasePassword
                   service: BarbicanPassword
-                description: 'TODO(dmendiza): Maybe we''ll add SimpleCrypto key here?
-                  PasswordSelectors - Selectors to identify the DB and ServiceUser
-                  password from the Secret'
+                  simplecryptokek: BarbicanSimpleCryptoKEK
+                description: PasswordSelectors - Selectors to identify the DB and
+                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: BarbicanDatabasePassword
@@ -616,6 +616,9 @@ spec:
                     default: BarbicanPassword
                     description: Service - Selector to get the barbican service user
                       password from the Secret
+                    type: string
+                  simplecryptokek:
+                    default: SimpleCryptoKEK
                     type: string
                 type: object
               preserveJobs:
@@ -629,6 +632,7 @@ spec:
                   that is created and used in Barbican
                 type: string
               secret:
+                default: osp-secret
                 description: Secret containing all passwords / keys needed
                 type: string
               serviceAccount:
@@ -640,8 +644,10 @@ spec:
                 description: ServiceUser - optional username used for this service
                   to register in keystone
                 type: string
-              simpleCryptoBackendKEKSecret:
-                description: Secret containing SimpleCrypto KEK
+              simpleCryptoBackendSecret:
+                default: osp-secret
+                description: Secret containing the Key Encryption Key (KEK) used for
+                  the Simple Crypto backend
                 type: string
             required:
             - barbicanAPI

--- a/api/bases/barbican.openstack.org_barbicanworkers.yaml
+++ b/api/bases/barbican.openstack.org_barbicanworkers.yaml
@@ -91,9 +91,9 @@ spec:
                 default:
                   database: BarbicanDatabasePassword
                   service: BarbicanPassword
-                description: 'TODO(dmendiza): Maybe we''ll add SimpleCrypto key here?
-                  PasswordSelectors - Selectors to identify the DB and ServiceUser
-                  password from the Secret'
+                  simplecryptokek: BarbicanSimpleCryptoKEK
+                description: PasswordSelectors - Selectors to identify the DB and
+                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: BarbicanDatabasePassword
@@ -104,6 +104,9 @@ spec:
                     default: BarbicanPassword
                     description: Service - Selector to get the barbican service user
                       password from the Secret
+                    type: string
+                  simplecryptokek:
+                    default: SimpleCryptoKEK
                     type: string
                 type: object
               rabbitMqClusterName:
@@ -168,6 +171,7 @@ spec:
                     type: object
                 type: object
               secret:
+                default: osp-secret
                 description: Secret containing all passwords / keys needed
                 type: string
               serviceAccount:
@@ -179,8 +183,10 @@ spec:
                 description: ServiceUser - optional username used for this service
                   to register in keystone
                 type: string
-              simpleCryptoBackendKEKSecret:
-                description: Secret containing SimpleCrypto KEK
+              simpleCryptoBackendSecret:
+                default: osp-secret
+                description: Secret containing the Key Encryption Key (KEK) used for
+                  the Simple Crypto backend
                 type: string
               tls:
                 description: TLS - Parameters related to the TLS

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -32,16 +32,17 @@ type BarbicanTemplate struct {
 	RabbitMqClusterName string `json:"rabbitMqClusterName"`
 
 	// +kubebuilder:validation:Optional
-	// Secret containing SimpleCrypto KEK
-	SimpleCryptoBackendKEKSecret string `json:"simpleCryptoBackendKEKSecret,omitempty"`
+	// +kubebuilder:default=osp-secret
+	// Secret containing the Key Encryption Key (KEK) used for the Simple Crypto backend
+	SimpleCryptoBackendSecret string `json:"simpleCryptoBackendSecret"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=osp-secret
 	// Secret containing all passwords / keys needed
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: BarbicanDatabasePassword, service: BarbicanPassword}
-	// TODO(dmendiza): Maybe we'll add SimpleCrypto key here?
+	// +kubebuilder:default={database: BarbicanDatabasePassword, service: BarbicanPassword, simplecryptokek: BarbicanSimpleCryptoKEK}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
@@ -114,4 +115,7 @@ type PasswordSelector struct {
 	// +kubebuilder:default="BarbicanPassword"
 	// Service - Selector to get the barbican service user password from the Secret
 	Service string `json:"service"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="SimpleCryptoKEK"
+	SimpleCryptoKEK string `json:"simplecryptokek"`
 }

--- a/config/crd/bases/barbican.openstack.org_barbicanapis.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicanapis.yaml
@@ -271,9 +271,9 @@ spec:
                 default:
                   database: BarbicanDatabasePassword
                   service: BarbicanPassword
-                description: 'TODO(dmendiza): Maybe we''ll add SimpleCrypto key here?
-                  PasswordSelectors - Selectors to identify the DB and ServiceUser
-                  password from the Secret'
+                  simplecryptokek: BarbicanSimpleCryptoKEK
+                description: PasswordSelectors - Selectors to identify the DB and
+                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: BarbicanDatabasePassword
@@ -284,6 +284,9 @@ spec:
                     default: BarbicanPassword
                     description: Service - Selector to get the barbican service user
                       password from the Secret
+                    type: string
+                  simplecryptokek:
+                    default: SimpleCryptoKEK
                     type: string
                 type: object
               rabbitMqClusterName:
@@ -348,6 +351,7 @@ spec:
                     type: object
                 type: object
               secret:
+                default: osp-secret
                 description: Secret containing all passwords / keys needed
                 type: string
               serviceAccount:
@@ -359,8 +363,10 @@ spec:
                 description: ServiceUser - optional username used for this service
                   to register in keystone
                 type: string
-              simpleCryptoBackendKEKSecret:
-                description: Secret containing SimpleCrypto KEK
+              simpleCryptoBackendSecret:
+                default: osp-secret
+                description: Secret containing the Key Encryption Key (KEK) used for
+                  the Simple Crypto backend
                 type: string
               tls:
                 description: TLS - Parameters related to the TLS

--- a/config/crd/bases/barbican.openstack.org_barbicankeystonelisteners.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicankeystonelisteners.yaml
@@ -93,9 +93,9 @@ spec:
                 default:
                   database: BarbicanDatabasePassword
                   service: BarbicanPassword
-                description: 'TODO(dmendiza): Maybe we''ll add SimpleCrypto key here?
-                  PasswordSelectors - Selectors to identify the DB and ServiceUser
-                  password from the Secret'
+                  simplecryptokek: BarbicanSimpleCryptoKEK
+                description: PasswordSelectors - Selectors to identify the DB and
+                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: BarbicanDatabasePassword
@@ -106,6 +106,9 @@ spec:
                     default: BarbicanPassword
                     description: Service - Selector to get the barbican service user
                       password from the Secret
+                    type: string
+                  simplecryptokek:
+                    default: SimpleCryptoKEK
                     type: string
                 type: object
               rabbitMqClusterName:
@@ -170,6 +173,7 @@ spec:
                     type: object
                 type: object
               secret:
+                default: osp-secret
                 description: Secret containing all passwords / keys needed
                 type: string
               serviceAccount:
@@ -181,8 +185,10 @@ spec:
                 description: ServiceUser - optional username used for this service
                   to register in keystone
                 type: string
-              simpleCryptoBackendKEKSecret:
-                description: Secret containing SimpleCrypto KEK
+              simpleCryptoBackendSecret:
+                default: osp-secret
+                description: Secret containing the Key Encryption Key (KEK) used for
+                  the Simple Crypto backend
                 type: string
               tls:
                 description: TLS - Parameters related to the TLS

--- a/config/crd/bases/barbican.openstack.org_barbicans.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicans.yaml
@@ -603,9 +603,9 @@ spec:
                 default:
                   database: BarbicanDatabasePassword
                   service: BarbicanPassword
-                description: 'TODO(dmendiza): Maybe we''ll add SimpleCrypto key here?
-                  PasswordSelectors - Selectors to identify the DB and ServiceUser
-                  password from the Secret'
+                  simplecryptokek: BarbicanSimpleCryptoKEK
+                description: PasswordSelectors - Selectors to identify the DB and
+                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: BarbicanDatabasePassword
@@ -616,6 +616,9 @@ spec:
                     default: BarbicanPassword
                     description: Service - Selector to get the barbican service user
                       password from the Secret
+                    type: string
+                  simplecryptokek:
+                    default: SimpleCryptoKEK
                     type: string
                 type: object
               preserveJobs:
@@ -629,6 +632,7 @@ spec:
                   that is created and used in Barbican
                 type: string
               secret:
+                default: osp-secret
                 description: Secret containing all passwords / keys needed
                 type: string
               serviceAccount:
@@ -640,8 +644,10 @@ spec:
                 description: ServiceUser - optional username used for this service
                   to register in keystone
                 type: string
-              simpleCryptoBackendKEKSecret:
-                description: Secret containing SimpleCrypto KEK
+              simpleCryptoBackendSecret:
+                default: osp-secret
+                description: Secret containing the Key Encryption Key (KEK) used for
+                  the Simple Crypto backend
                 type: string
             required:
             - barbicanAPI

--- a/config/crd/bases/barbican.openstack.org_barbicanworkers.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicanworkers.yaml
@@ -91,9 +91,9 @@ spec:
                 default:
                   database: BarbicanDatabasePassword
                   service: BarbicanPassword
-                description: 'TODO(dmendiza): Maybe we''ll add SimpleCrypto key here?
-                  PasswordSelectors - Selectors to identify the DB and ServiceUser
-                  password from the Secret'
+                  simplecryptokek: BarbicanSimpleCryptoKEK
+                description: PasswordSelectors - Selectors to identify the DB and
+                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: BarbicanDatabasePassword
@@ -104,6 +104,9 @@ spec:
                     default: BarbicanPassword
                     description: Service - Selector to get the barbican service user
                       password from the Secret
+                    type: string
+                  simplecryptokek:
+                    default: SimpleCryptoKEK
                     type: string
                 type: object
               rabbitMqClusterName:
@@ -168,6 +171,7 @@ spec:
                     type: object
                 type: object
               secret:
+                default: osp-secret
                 description: Secret containing all passwords / keys needed
                 type: string
               serviceAccount:
@@ -179,8 +183,10 @@ spec:
                 description: ServiceUser - optional username used for this service
                   to register in keystone
                 type: string
-              simpleCryptoBackendKEKSecret:
-                description: Secret containing SimpleCrypto KEK
+              simpleCryptoBackendSecret:
+                default: osp-secret
+                description: Secret containing the Key Encryption Key (KEK) used for
+                  the Simple Crypto backend
                 type: string
               tls:
                 description: TLS - Parameters related to the TLS

--- a/config/samples/barbican_v1beta1_barbican.yaml
+++ b/config/samples/barbican_v1beta1_barbican.yaml
@@ -18,6 +18,7 @@ spec:
   passwordSelectors:
     database: BarbicanDatabasePassword
     service: BarbicanPassword
+    simplecryptokek: BarbicanSimpleCryptoKEK
   preserveJobs: true
   nodeSelector:
     node: controller

--- a/controllers/barbicanapi_controller.go
+++ b/controllers/barbicanapi_controller.go
@@ -274,6 +274,11 @@ func (r *BarbicanAPIReconciler) generateServiceConfigs(
 		return err
 	}
 
+	simpleCryptoSecret, _, err := secret.GetSecret(ctx, h, instance.Spec.SimpleCryptoBackendSecret, instance.Namespace)
+	if err != nil {
+		return err
+	}
+
 	transportURLSecret, _, err := secret.GetSecret(ctx, h, instance.Spec.TransportURLSecret, instance.Namespace)
 	if err != nil {
 		return err
@@ -294,7 +299,7 @@ func (r *BarbicanAPIReconciler) generateServiceConfigs(
 		"ServiceURL":       "https://barbican.openstack.svc:9311",
 		"TransportURL":     string(transportURLSecret.Data["transport_url"]),
 		"LogFile":          fmt.Sprintf("%s%s.log", barbican.BarbicanLogPath, instance.Name),
-		"SimpleCryptoKEK":  string(ospSecret.Data["BarbicanSimpleCryptoKEK"]),
+		"SimpleCryptoKEK":  string(simpleCryptoSecret.Data[instance.Spec.PasswordSelectors.SimpleCryptoKEK]),
 		"EnableSecureRBAC": instance.Spec.EnableSecureRBAC,
 	}
 

--- a/controllers/barbicanworker_controller.go
+++ b/controllers/barbicanworker_controller.go
@@ -242,6 +242,11 @@ func (r *BarbicanWorkerReconciler) generateServiceConfigs(
 		return err
 	}
 
+	simpleCryptoSecret, _, err := secret.GetSecret(ctx, h, instance.Spec.SimpleCryptoBackendSecret, instance.Namespace)
+	if err != nil {
+		return err
+	}
+
 	transportURLSecret, _, err := secret.GetSecret(ctx, h, instance.Spec.TransportURLSecret, instance.Namespace)
 	if err != nil {
 		return err
@@ -258,7 +263,7 @@ func (r *BarbicanWorkerReconciler) generateServiceConfigs(
 		),
 		"TransportURL":    string(transportURLSecret.Data["transport_url"]),
 		"LogFile":         fmt.Sprintf("%s%s.log", barbican.BarbicanLogPath, instance.Name),
-		"SimpleCryptoKEK": string(ospSecret.Data["BarbicanSimpleCryptoKEK"]),
+		"SimpleCryptoKEK": string(simpleCryptoSecret.Data[instance.Spec.PasswordSelectors.SimpleCryptoKEK]),
 	}
 
 	return GenerateConfigsGeneric(ctx, h, instance, envVars, templateParameters, customData, labels, false)

--- a/tests/functional/barbican_controller_test.go
+++ b/tests/functional/barbican_controller_test.go
@@ -2,6 +2,7 @@ package functional
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -44,8 +44,9 @@ func CreateKeystoneAPISecret(namespace string, name string) *corev1.Secret {
 
 func GetDefaultBarbicanSpec() map[string]interface{} {
 	return map[string]interface{}{
-		"databaseInstance": "openstack",
-		"secret":           SecretName,
+		"databaseInstance":          "openstack",
+		"secret":                    SecretName,
+		"simpleCryptoBackendSecret": SecretName,
 	}
 }
 
@@ -87,6 +88,7 @@ func CreateBarbicanSecret(namespace string, name string) *corev1.Secret {
 		map[string][]byte{
 			"BarbicanDatabasePassword": []byte("12345678"),
 			"BarbicanPassword":         []byte("12345678"),
+			"BarbicanSimpleCryptoKEK":  []byte("sEFmdFjDUqRM2VemYslV5yGNWjokioJXsg8Nrlc3drU="),
 		},
 	)
 }
@@ -144,9 +146,10 @@ func GetBarbicanAPI(name types.NamespacedName) *barbicanv1.BarbicanAPI {
 
 func GetTLSBarbicanSpec() map[string]interface{} {
 	return map[string]interface{}{
-		"databaseInstance": "openstack",
-		"secret":           SecretName,
-		"barbicanAPI":      GetTLSBarbicanAPISpec(),
+		"databaseInstance":          "openstack",
+		"secret":                    SecretName,
+		"simpleCryptoBackendSecret": SecretName,
+		"barbicanAPI":               GetTLSBarbicanAPISpec(),
 	}
 }
 
@@ -170,13 +173,14 @@ func GetTLSBarbicanAPISpec() map[string]interface{} {
 
 func GetDefaultBarbicanAPISpec() map[string]interface{} {
 	return map[string]interface{}{
-		"secret":             SecretName,
-		"replicas":           1,
-		"databaseHostname":   barbicanTest.DatabaseHostname,
-		"databaseInstance":   barbicanTest.DatabaseInstance,
-		"containerImage":     barbicanTest.ContainerImage,
-		"serviceAccount":     barbicanTest.BarbicanSA.Name,
-		"transportURLSecret": barbicanTest.RabbitmqSecretName,
+		"secret":                    SecretName,
+		"simpleCryptoBackendSecret": SecretName,
+		"replicas":                  1,
+		"databaseHostname":          barbicanTest.DatabaseHostname,
+		"databaseInstance":          barbicanTest.DatabaseInstance,
+		"containerImage":            barbicanTest.ContainerImage,
+		"serviceAccount":            barbicanTest.BarbicanSA.Name,
+		"transportURLSecret":        barbicanTest.RabbitmqSecretName,
 	}
 }
 


### PR DESCRIPTION
This patch adds the ability to separate the Key Encryption Key (KEK) used by the Simple Crypto backend from the general purpose osp-secret used with the rest of openstack.

By default we still use osp-secret, but the barbican spec can now be configured to use a separate secret as well as a custom key for retrieving the value from the secret.

Jira: [OSPRH-2390](https://issues.redhat.com//browse/OSPRH-2390)