### PR TITLE
[tlse] TLS database connection

### DIFF
--- a/controllers/barbican_controller.go
+++ b/controllers/barbican_controller.go
@@ -45,6 +45,7 @@ import (
 	common_rbac "github.com/openstack-k8s-operators/lib-common/modules/common/rbac"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	oko_secret "github.com/openstack-k8s-operators/lib-common/modules/common/secret"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -265,7 +266,18 @@ func (r *BarbicanReconciler) reconcileNormal(ctx context.Context, instance *barb
 	// Setting this here at the top level
 	instance.Spec.ServiceAccount = instance.RbacResourceName()
 
-	err = r.generateServiceConfig(ctx, helper, instance, &configVars, serviceLabels)
+	//
+	// create service DB instance
+	//
+	db, result, err := r.ensureDB(ctx, helper, instance)
+	if err != nil {
+		return ctrl.Result{}, err
+	} else if (result != ctrl.Result{}) {
+		return result, nil
+	}
+	// create service DB - end
+
+	err = r.generateServiceConfig(ctx, helper, instance, &configVars, serviceLabels, db)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.ServiceConfigReadyCondition,
@@ -527,6 +539,7 @@ func (r *BarbicanReconciler) generateServiceConfig(
 	instance *barbicanv1beta1.Barbican,
 	envVars *map[string]env.Setter,
 	serviceLabels map[string]string,
+	db *mariadbv1.Database,
 ) error {
 	Log := r.GetLogger(ctx)
 	Log.Info("generateServiceConfigMaps - Barbican controller")
@@ -544,7 +557,14 @@ func (r *BarbicanReconciler) generateServiceConfig(
 		return err
 	}
 
-	customData := map[string]string{barbican.CustomConfigFileName: instance.Spec.CustomServiceConfig}
+	var tlsCfg *tls.Service
+	if instance.Spec.BarbicanAPI.TLS.Ca.CaBundleSecretName != "" {
+		tlsCfg = &tls.Service{}
+	}
+	customData := map[string]string{
+		barbican.CustomConfigFileName: instance.Spec.CustomServiceConfig,
+		"my.cnf":                      db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
+	}
 
 	for key, data := range instance.Spec.DefaultConfigOverwrite {
 		customData[key] = data
@@ -560,7 +580,7 @@ func (r *BarbicanReconciler) generateServiceConfig(
 	}
 
 	templateParameters := map[string]interface{}{
-		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s",
+		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s?read_default_file=/etc/my.cnf",
 			instance.Spec.DatabaseUser,
 			string(ospSecret.Data[instance.Spec.PasswordSelectors.Database]),
 			instance.Status.DatabaseHostname,
@@ -745,63 +765,6 @@ func (r *BarbicanReconciler) reconcileInit(
 	}
 
 	//
-	// create service DB instance
-	//
-	db := mariadbv1.NewDatabase(
-		instance.Name,
-		instance.Spec.DatabaseUser,
-		instance.Spec.Secret,
-		map[string]string{
-			"dbName": instance.Spec.DatabaseInstance,
-		},
-	)
-	// create or patch the DB
-	ctrlResult, err := db.CreateOrPatchDB(
-		ctx,
-		helper,
-	)
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.DBReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.DBReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
-	if (ctrlResult != ctrl.Result{}) {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.DBReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			condition.DBReadyRunningMessage))
-		return ctrlResult, nil
-	}
-	// wait for the DB to be setup
-	ctrlResult, err = db.WaitForDBCreated(ctx, helper)
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.DBReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.DBReadyErrorMessage,
-			err.Error()))
-		return ctrlResult, err
-	}
-	if (ctrlResult != ctrl.Result{}) {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.DBReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			condition.DBReadyRunningMessage))
-		return ctrlResult, nil
-	}
-	// update Status.DatabaseHostname, used to config the service
-	instance.Status.DatabaseHostname = db.GetDatabaseHostname()
-	instance.Status.Conditions.MarkTrue(condition.DBReadyCondition, condition.DBReadyMessage)
-	// create service DB - end
-
-	//
 	// create Keystone service and users
 	//
 	_, _, err = oko_secret.GetSecret(ctx, helper, instance.Spec.Secret, instance.Namespace)
@@ -823,7 +786,7 @@ func (r *BarbicanReconciler) reconcileInit(
 	}
 
 	ksSvc := keystonev1.NewKeystoneService(ksSvcSpec, instance.Namespace, serviceLabels, time.Duration(10)*time.Second)
-	ctrlResult, err = ksSvc.CreateOrPatch(ctx, helper)
+	ctrlResult, err := ksSvc.CreateOrPatch(ctx, helper)
 	if err != nil {
 		return ctrlResult, err
 	}
@@ -892,4 +855,67 @@ func (r *BarbicanReconciler) reconcileInit(
 
 	Log.Info(fmt.Sprintf("Reconciled Service '%s' init successfully", instance.Name))
 	return ctrl.Result{}, nil
+}
+
+func (r *BarbicanReconciler) ensureDB(
+	ctx context.Context,
+	h *helper.Helper,
+	instance *barbicanv1beta1.Barbican,
+) (*mariadbv1.Database, ctrl.Result, error) {
+	//
+	// create service DB instance
+	//
+	db := mariadbv1.NewDatabase(
+		barbican.DatabaseName,
+		instance.Spec.DatabaseUser,
+		instance.Spec.Secret,
+		map[string]string{
+			"dbName": instance.Spec.DatabaseInstance,
+		},
+	)
+	// create or patch the DB
+	ctrlResult, err := db.CreateOrPatchDB(
+		ctx,
+		h,
+	)
+	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.DBReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.DBReadyErrorMessage,
+			err.Error()))
+		return db, ctrl.Result{}, err
+	}
+	if (ctrlResult != ctrl.Result{}) {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.DBReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			condition.DBReadyRunningMessage))
+		return db, ctrlResult, nil
+	}
+	// wait for the DB to be setup
+	ctrlResult, err = db.WaitForDBCreated(ctx, h)
+	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.DBReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.DBReadyErrorMessage,
+			err.Error()))
+		return db, ctrlResult, err
+	}
+	if (ctrlResult != ctrl.Result{}) {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.DBReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			condition.DBReadyRunningMessage))
+		return db, ctrlResult, nil
+	}
+	// update Status.DatabaseHostname, used to config the service
+	instance.Status.DatabaseHostname = db.GetDatabaseHostname()
+	instance.Status.Conditions.MarkTrue(condition.DBReadyCondition, condition.DBReadyMessage)
+	return db, ctrlResult, nil
 }

--- a/controllers/barbicanworker_controller.go
+++ b/controllers/barbicanworker_controller.go
@@ -25,6 +25,7 @@ import (
 	barbicanv1beta1 "github.com/openstack-k8s-operators/barbican-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/barbican-operator/pkg/barbican"
 	"github.com/openstack-k8s-operators/barbican-operator/pkg/barbicanworker"
+	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
@@ -228,8 +229,19 @@ func (r *BarbicanWorkerReconciler) generateServiceConfigs(
 	Log.Info("[Worker] generateServiceConfigs - reconciling")
 	labels := labels.GetLabels(instance, labels.GetGroupLabel(barbican.ServiceName), map[string]string{})
 
+	db, err := mariadbv1.GetDatabaseByName(ctx, h, barbican.DatabaseName)
+	if err != nil {
+		return err
+	}
+	var tlsCfg *tls.Service
+	if instance.Spec.TLS.CaBundleSecretName != "" {
+		tlsCfg = &tls.Service{}
+	}
 	// customData hold any customization for the service.
-	customData := map[string]string{common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
+	customData := map[string]string{
+		common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig,
+		"my.cnf":                           db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
+	}
 
 	Log.Info(fmt.Sprintf("[Worker] instance type %s", instance.GetObjectKind().GroupVersionKind().Kind))
 
@@ -250,7 +262,7 @@ func (r *BarbicanWorkerReconciler) generateServiceConfigs(
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 
 	templateParameters := map[string]interface{}{
-		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s",
+		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s?read_default_file=/etc/my.cnf",
 			instance.Spec.DatabaseUser,
 			string(ospSecret.Data[instance.Spec.PasswordSelectors.Database]),
 			instance.Spec.DatabaseHostname,

--- a/pkg/barbican/volumes.go
+++ b/pkg/barbican/volumes.go
@@ -37,6 +37,12 @@ func GetVolumeMounts(secretNames []string, svc []storage.PropagationType) []core
 			MountPath: "/var/lib/config-data/default",
 			ReadOnly:  true,
 		},
+		{
+			Name:      "config-data",
+			MountPath: "/etc/my.cnf",
+			SubPath:   "my.cnf",
+			ReadOnly:  true,
+		},
 	}
 
 	_, secretConfig := GetConfigSecretVolumes(secretNames)

--- a/tests/functional/barbican_controller_test.go
+++ b/tests/functional/barbican_controller_test.go
@@ -2,6 +2,7 @@ package functional
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
@@ -114,6 +115,15 @@ var _ = Describe("Barbican controller", func() {
 				corev1.ConditionFalse,
 			)
 		})
+		It("should create config-data and scripts ConfigMaps", func() {
+			mariadb.SimulateMariaDBAccountCompleted(barbicanTest.Instance)
+			mariadb.SimulateMariaDBDatabaseCompleted(barbicanTest.Instance)
+			cf := th.GetSecret(barbicanTest.BarbicanConfigSecret)
+			Expect(cf).ShouldNot(BeNil())
+			conf := cf.Data["my.cnf"]
+			Expect(conf).To(
+				ContainSubstring("[client]\nssl=0"))
+		})
 		It("Should fail if db-sync job fails when DB is Created", func() {
 			mariadb.SimulateMariaDBAccountCompleted(barbicanTest.Instance)
 			mariadb.SimulateMariaDBDatabaseCompleted(barbicanTest.Instance)
@@ -210,7 +220,7 @@ var _ = Describe("Barbican controller", func() {
 			infra.SimulateTransportURLReady(barbicanTest.BarbicanTransportURL)
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(barbicanTest.Instance.Namespace))
 			mariadb.SimulateMariaDBAccountCompleted(barbicanTest.Instance)
-			mariadb.SimulateMariaDBDatabaseCompleted(barbicanTest.Instance)
+			mariadb.SimulateMariaDBTLSDatabaseCompleted(barbicanTest.Instance)
 			th.SimulateJobSuccess(barbicanTest.BarbicanDBSync)
 		})
 
@@ -244,6 +254,14 @@ var _ = Describe("Barbican controller", func() {
 
 			Expect(container.ReadinessProbe.HTTPGet.Scheme).To(Equal(corev1.URISchemeHTTPS))
 			Expect(container.LivenessProbe.HTTPGet.Scheme).To(Equal(corev1.URISchemeHTTPS))
+		})
+
+		It("should create config-data and scripts ConfigMaps", func() {
+			cf := th.GetSecret(barbicanTest.BarbicanConfigSecret)
+			Expect(cf).ShouldNot(BeNil())
+			conf := cf.Data["my.cnf"]
+			Expect(conf).To(
+				ContainSubstring("[client]\nssl-ca=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem\nssl=1"))
 		})
 	})
 })

--- a/tests/kuttl/tests/barbican_tls/01-assert.yaml
+++ b/tests/kuttl/tests/barbican_tls/01-assert.yaml
@@ -116,6 +116,10 @@ spec:
             - mountPath: /var/lib/config-data/default
               name: config-data
               readOnly: true
+            - mountPath: /etc/my.cnf
+              name: config-data
+              readOnly: true
+              subPath: my.cnf
             - mountPath: /var/lib/kolla/config_files/config.json
               name: config-data
               readOnly: true


### PR DESCRIPTION
The my.cnf file gets added to the secret holding the service configs. The content of my.cnf is centrally managed in the mariadb-operator and retrieved calling db.GetDatabaseClientConfig(tlsCfg)

Depends-On: https://github.com/openstack-k8s-operators/mariadb-operator/pull/190
Depends-On: https://github.com/openstack-k8s-operators/mariadb-operator/pull/191

Jira: [OSPRH-4547](https://issues.redhat.com//browse/OSPRH-4547)