### PR TITLE
migrate from databaseUsername to databaseAccount and fully use MariaDBAccount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,9 @@ PROC_CMD = --procs ${PROCS}
 
 .PHONY: test
 test: manifests generate fmt vet envtest ginkgo ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) --trace --cover --coverpkg=../../pkg/barbican,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic ${PROC_CMD} $(GINKGO_ARGS) ./tests/...
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
+	OPERATOR_TEMPLATES="$(shell pwd)/templates" \
+	$(GINKGO) --trace --cover --coverpkg=../../pkg/barbican,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic ${PROC_CMD} $(GINKGO_ARGS) ./tests/...
 
 ##@ Build
 

--- a/api/bases/barbican.openstack.org_barbicanapis.yaml
+++ b/api/bases/barbican.openstack.org_barbicanapis.yaml
@@ -54,6 +54,11 @@ spec:
                 items:
                   type: string
                 type: array
+              databaseAccount:
+                default: barbican
+                description: DatabaseAccount - optional MariaDBAccount CR name used
+                  for barbican DB, defaults to barbican
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Barbican Database Hostname
                 type: string
@@ -61,11 +66,6 @@ spec:
                 description: 'MariaDB instance name TODO(dmendiza): Is this comment
                   right? Right now required by the maridb-operator to get the credentials
                   from the instance to create the DB Might not be required in future'
-                type: string
-              databaseUser:
-                default: barbican
-                description: DatabaseUser - optional username used for barbican DB,
-                  defaults to barbican
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -269,17 +269,11 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: BarbicanDatabasePassword
                   service: BarbicanPassword
                   simplecryptokek: BarbicanSimpleCryptoKEK
-                description: PasswordSelectors - Selectors to identify the DB and
-                  ServiceUser password from the Secret
+                description: PasswordSelectors - Selectors to identify the ServiceUser
+                  password from the Secret
                 properties:
-                  database:
-                    default: BarbicanDatabasePassword
-                    description: Database - Selector to get the barbican database
-                      user password from the Secret
-                    type: string
                   service:
                     default: BarbicanPassword
                     description: Service - Selector to get the barbican service user

--- a/api/bases/barbican.openstack.org_barbicankeystonelisteners.yaml
+++ b/api/bases/barbican.openstack.org_barbicankeystonelisteners.yaml
@@ -56,17 +56,17 @@ spec:
                 items:
                   type: string
                 type: array
+              databaseAccount:
+                default: barbican
+                description: DatabaseAccount - optional MariaDBAccount CR name used
+                  for barbican DB, defaults to barbican
+                type: string
               databaseHostname:
                 type: string
               databaseInstance:
                 description: 'MariaDB instance name TODO(dmendiza): Is this comment
                   right? Right now required by the maridb-operator to get the credentials
                   from the instance to create the DB Might not be required in future'
-                type: string
-              databaseUser:
-                default: barbican
-                description: DatabaseUser - optional username used for barbican DB,
-                  defaults to barbican
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -91,17 +91,11 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: BarbicanDatabasePassword
                   service: BarbicanPassword
                   simplecryptokek: BarbicanSimpleCryptoKEK
-                description: PasswordSelectors - Selectors to identify the DB and
-                  ServiceUser password from the Secret
+                description: PasswordSelectors - Selectors to identify the ServiceUser
+                  password from the Secret
                 properties:
-                  database:
-                    default: BarbicanDatabasePassword
-                    description: Database - Selector to get the barbican database
-                      user password from the Secret
-                    type: string
                   service:
                     default: BarbicanPassword
                     description: Service - Selector to get the barbican service user

--- a/api/bases/barbican.openstack.org_barbicans.yaml
+++ b/api/bases/barbican.openstack.org_barbicans.yaml
@@ -574,15 +574,15 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: barbican
+                description: DatabaseAccount - optional MariaDBAccount CR name used
+                  for barbican DB, defaults to barbican
+                type: string
               databaseInstance:
                 description: 'MariaDB instance name TODO(dmendiza): Is this comment
                   right? Right now required by the maridb-operator to get the credentials
                   from the instance to create the DB Might not be required in future'
-                type: string
-              databaseUser:
-                default: barbican
-                description: DatabaseUser - optional username used for barbican DB,
-                  defaults to barbican
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -601,17 +601,11 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: BarbicanDatabasePassword
                   service: BarbicanPassword
                   simplecryptokek: BarbicanSimpleCryptoKEK
-                description: PasswordSelectors - Selectors to identify the DB and
-                  ServiceUser password from the Secret
+                description: PasswordSelectors - Selectors to identify the ServiceUser
+                  password from the Secret
                 properties:
-                  database:
-                    default: BarbicanDatabasePassword
-                    description: Database - Selector to get the barbican database
-                      user password from the Secret
-                    type: string
                   service:
                     default: BarbicanPassword
                     description: Service - Selector to get the barbican service user

--- a/api/bases/barbican.openstack.org_barbicanworkers.yaml
+++ b/api/bases/barbican.openstack.org_barbicanworkers.yaml
@@ -54,17 +54,17 @@ spec:
                 items:
                   type: string
                 type: array
+              databaseAccount:
+                default: barbican
+                description: DatabaseAccount - optional MariaDBAccount CR name used
+                  for barbican DB, defaults to barbican
+                type: string
               databaseHostname:
                 type: string
               databaseInstance:
                 description: 'MariaDB instance name TODO(dmendiza): Is this comment
                   right? Right now required by the maridb-operator to get the credentials
                   from the instance to create the DB Might not be required in future'
-                type: string
-              databaseUser:
-                default: barbican
-                description: DatabaseUser - optional username used for barbican DB,
-                  defaults to barbican
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -89,17 +89,11 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: BarbicanDatabasePassword
                   service: BarbicanPassword
                   simplecryptokek: BarbicanSimpleCryptoKEK
-                description: PasswordSelectors - Selectors to identify the DB and
-                  ServiceUser password from the Secret
+                description: PasswordSelectors - Selectors to identify the ServiceUser
+                  password from the Secret
                 properties:
-                  database:
-                    default: BarbicanDatabasePassword
-                    description: Database - Selector to get the barbican database
-                      user password from the Secret
-                    type: string
                   service:
                     default: BarbicanPassword
                     description: Service - Selector to get the barbican service user

--- a/api/go.mod
+++ b/api/go.mod
@@ -3,8 +3,8 @@ module github.com/openstack-k8s-operators/barbican-operator/api
 go 1.20
 
 require (
-	github.com/onsi/ginkgo/v2 v2.14.0
-	github.com/onsi/gomega v1.30.0
+	github.com/onsi/ginkgo/v2 v2.15.0
+	github.com/onsi/gomega v1.31.1
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240216173409-86913e6d5885
 	k8s.io/api v0.28.3
 	k8s.io/apimachinery v0.28.3

--- a/api/go.sum
+++ b/api/go.sum
@@ -81,10 +81,10 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/onsi/ginkgo/v2 v2.14.0 h1:vSmGj2Z5YPb9JwCWT6z6ihcUvDhuXLc3sJiqd3jMKAY=
-github.com/onsi/ginkgo/v2 v2.14.0/go.mod h1:JkUdW7JkN0V6rFvsHcJ478egV3XH9NxpD27Hal/PhZw=
-github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
-github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
+github.com/onsi/ginkgo/v2 v2.15.0 h1:79HwNRBAZHOEwrczrgSOPy+eFTTlIGELKy5as+ClttY=
+github.com/onsi/ginkgo/v2 v2.15.0/go.mod h1:HlxMHtYF57y6Dpf+mc5529KKmSq9h2FpCF+/ZkwUxKM=
+github.com/onsi/gomega v1.31.1 h1:KYppCUK+bUgAZwHOu7EXVBKyQA6ILvOESHkn/tgoqvo=
+github.com/onsi/gomega v1.31.1/go.mod h1:y40C95dwAD1Nz36SsEnxvfFe8FFfNxzI5eJ0EYGyAy0=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240216173409-86913e6d5885 h1:o7KZaxKt8Dr97ZJIBPW0P482gLyFEURKF89fizcJCBQ=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240216173409-86913e6d5885/go.mod h1:bQwzyQtWCR9F0+IvWZ30J9d1lB6tcX3CNJ0Ten1smDw=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -22,8 +22,8 @@ type BarbicanTemplate struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=barbican
-	// DatabaseUser - optional username used for barbican DB, defaults to barbican
-	DatabaseUser string `json:"databaseUser"`
+	// DatabaseAccount - optional MariaDBAccount CR name used for barbican DB, defaults to barbican
+	DatabaseAccount string `json:"databaseAccount"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default=rabbitmq
@@ -42,8 +42,8 @@ type BarbicanTemplate struct {
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: BarbicanDatabasePassword, service: BarbicanPassword, simplecryptokek: BarbicanSimpleCryptoKEK}
-	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
+	// +kubebuilder:default={service: BarbicanPassword, simplecryptokek: BarbicanSimpleCryptoKEK}
+	// PasswordSelectors - Selectors to identify the ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Optional
@@ -103,10 +103,6 @@ type BarbicanComponentTemplate struct {
 
 // PasswordSelector to identify the DB and AdminUser password from the Secret
 type PasswordSelector struct {
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="BarbicanDatabasePassword"
-	// Database - Selector to get the barbican database user password from the Secret
-	Database string `json:"database"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="BarbicanPassword"
 	// Service - Selector to get the barbican service user password from the Secret

--- a/config/crd/bases/barbican.openstack.org_barbicanapis.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicanapis.yaml
@@ -54,6 +54,11 @@ spec:
                 items:
                   type: string
                 type: array
+              databaseAccount:
+                default: barbican
+                description: DatabaseAccount - optional MariaDBAccount CR name used
+                  for barbican DB, defaults to barbican
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Barbican Database Hostname
                 type: string
@@ -61,11 +66,6 @@ spec:
                 description: 'MariaDB instance name TODO(dmendiza): Is this comment
                   right? Right now required by the maridb-operator to get the credentials
                   from the instance to create the DB Might not be required in future'
-                type: string
-              databaseUser:
-                default: barbican
-                description: DatabaseUser - optional username used for barbican DB,
-                  defaults to barbican
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -269,17 +269,11 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: BarbicanDatabasePassword
                   service: BarbicanPassword
                   simplecryptokek: BarbicanSimpleCryptoKEK
-                description: PasswordSelectors - Selectors to identify the DB and
-                  ServiceUser password from the Secret
+                description: PasswordSelectors - Selectors to identify the ServiceUser
+                  password from the Secret
                 properties:
-                  database:
-                    default: BarbicanDatabasePassword
-                    description: Database - Selector to get the barbican database
-                      user password from the Secret
-                    type: string
                   service:
                     default: BarbicanPassword
                     description: Service - Selector to get the barbican service user

--- a/config/crd/bases/barbican.openstack.org_barbicankeystonelisteners.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicankeystonelisteners.yaml
@@ -56,17 +56,17 @@ spec:
                 items:
                   type: string
                 type: array
+              databaseAccount:
+                default: barbican
+                description: DatabaseAccount - optional MariaDBAccount CR name used
+                  for barbican DB, defaults to barbican
+                type: string
               databaseHostname:
                 type: string
               databaseInstance:
                 description: 'MariaDB instance name TODO(dmendiza): Is this comment
                   right? Right now required by the maridb-operator to get the credentials
                   from the instance to create the DB Might not be required in future'
-                type: string
-              databaseUser:
-                default: barbican
-                description: DatabaseUser - optional username used for barbican DB,
-                  defaults to barbican
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -91,17 +91,11 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: BarbicanDatabasePassword
                   service: BarbicanPassword
                   simplecryptokek: BarbicanSimpleCryptoKEK
-                description: PasswordSelectors - Selectors to identify the DB and
-                  ServiceUser password from the Secret
+                description: PasswordSelectors - Selectors to identify the ServiceUser
+                  password from the Secret
                 properties:
-                  database:
-                    default: BarbicanDatabasePassword
-                    description: Database - Selector to get the barbican database
-                      user password from the Secret
-                    type: string
                   service:
                     default: BarbicanPassword
                     description: Service - Selector to get the barbican service user

--- a/config/crd/bases/barbican.openstack.org_barbicans.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicans.yaml
@@ -574,15 +574,15 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: barbican
+                description: DatabaseAccount - optional MariaDBAccount CR name used
+                  for barbican DB, defaults to barbican
+                type: string
               databaseInstance:
                 description: 'MariaDB instance name TODO(dmendiza): Is this comment
                   right? Right now required by the maridb-operator to get the credentials
                   from the instance to create the DB Might not be required in future'
-                type: string
-              databaseUser:
-                default: barbican
-                description: DatabaseUser - optional username used for barbican DB,
-                  defaults to barbican
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -601,17 +601,11 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: BarbicanDatabasePassword
                   service: BarbicanPassword
                   simplecryptokek: BarbicanSimpleCryptoKEK
-                description: PasswordSelectors - Selectors to identify the DB and
-                  ServiceUser password from the Secret
+                description: PasswordSelectors - Selectors to identify the ServiceUser
+                  password from the Secret
                 properties:
-                  database:
-                    default: BarbicanDatabasePassword
-                    description: Database - Selector to get the barbican database
-                      user password from the Secret
-                    type: string
                   service:
                     default: BarbicanPassword
                     description: Service - Selector to get the barbican service user

--- a/config/crd/bases/barbican.openstack.org_barbicanworkers.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicanworkers.yaml
@@ -54,17 +54,17 @@ spec:
                 items:
                   type: string
                 type: array
+              databaseAccount:
+                default: barbican
+                description: DatabaseAccount - optional MariaDBAccount CR name used
+                  for barbican DB, defaults to barbican
+                type: string
               databaseHostname:
                 type: string
               databaseInstance:
                 description: 'MariaDB instance name TODO(dmendiza): Is this comment
                   right? Right now required by the maridb-operator to get the credentials
                   from the instance to create the DB Might not be required in future'
-                type: string
-              databaseUser:
-                default: barbican
-                description: DatabaseUser - optional username used for barbican DB,
-                  defaults to barbican
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -89,17 +89,11 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: BarbicanDatabasePassword
                   service: BarbicanPassword
                   simplecryptokek: BarbicanSimpleCryptoKEK
-                description: PasswordSelectors - Selectors to identify the DB and
-                  ServiceUser password from the Secret
+                description: PasswordSelectors - Selectors to identify the ServiceUser
+                  password from the Secret
                 properties:
-                  database:
-                    default: BarbicanDatabasePassword
-                    description: Database - Selector to get the barbican database
-                      user password from the Secret
-                    type: string
                   service:
                     default: BarbicanPassword
                     description: Service - Selector to get the barbican service user

--- a/config/samples/barbican_v1beta1_barbican.yaml
+++ b/config/samples/barbican_v1beta1_barbican.yaml
@@ -12,7 +12,7 @@ spec:
   serviceAccount: barbican
   serviceUser: barbican
   databaseInstance: openstack
-  databaseUser: barbican
+  databaseAccount: barbican
   rabbitMqCusterName: barbican_rabbit
   secret: osp-secret
   passwordSelectors:

--- a/controllers/barbicanapi_controller.go
+++ b/controllers/barbicanapi_controller.go
@@ -253,7 +253,7 @@ func (r *BarbicanAPIReconciler) generateServiceConfigs(
 	Log.Info("generateServiceConfigs - reconciling")
 	labels := labels.GetLabels(instance, labels.GetGroupLabel(barbican.ServiceName), map[string]string{})
 
-	db, err := mariadbv1.GetDatabaseByName(ctx, h, barbican.DatabaseName)
+	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, h, barbican.DatabaseCRName, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil {
 		return err
 	}
@@ -298,10 +298,13 @@ func (r *BarbicanAPIReconciler) generateServiceConfigs(
 
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 
+	databaseAccount := db.GetAccount()
+	databaseSecret := db.GetSecret()
+
 	templateParameters := map[string]interface{}{
 		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s?read_default_file=/etc/my.cnf",
-			instance.Spec.DatabaseUser,
-			string(ospSecret.Data[instance.Spec.PasswordSelectors.Database]),
+			databaseAccount.Spec.UserName,
+			string(databaseSecret.Data[mariadbv1.DatabasePasswordSelector]),
 			instance.Spec.DatabaseHostname,
 			barbican.DatabaseName,
 		),

--- a/controllers/barbicankeystonelistener_controller.go
+++ b/controllers/barbicankeystonelistener_controller.go
@@ -234,7 +234,7 @@ func (r *BarbicanKeystoneListenerReconciler) generateServiceConfigs(
 	Log.Info("[KeystoneListener] generateServiceConfigs - reconciling")
 	labels := labels.GetLabels(instance, labels.GetGroupLabel(barbican.ServiceName), map[string]string{})
 
-	db, err := mariadbv1.GetDatabaseByName(ctx, h, barbican.DatabaseName)
+	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, h, barbican.DatabaseCRName, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil {
 		return err
 	}
@@ -263,11 +263,6 @@ func (r *BarbicanKeystoneListenerReconciler) generateServiceConfigs(
 	//	return err
 	//}
 
-	ospSecret, _, err := secret.GetSecret(ctx, h, instance.Spec.Secret, instance.Namespace)
-	if err != nil {
-		return err
-	}
-
 	transportURLSecret, _, err := secret.GetSecret(ctx, h, instance.Spec.TransportURLSecret, instance.Namespace)
 	if err != nil {
 		return err
@@ -275,10 +270,13 @@ func (r *BarbicanKeystoneListenerReconciler) generateServiceConfigs(
 
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 
+	databaseAccount := db.GetAccount()
+	databaseSecret := db.GetSecret()
+
 	templateParameters := map[string]interface{}{
 		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s?read_default_file=/etc/my.cnf",
-			instance.Spec.DatabaseUser,
-			string(ospSecret.Data[instance.Spec.PasswordSelectors.Database]),
+			databaseAccount.Spec.UserName,
+			string(databaseSecret.Data[mariadbv1.DatabasePasswordSelector]),
 			instance.Spec.DatabaseHostname,
 			barbican.DatabaseName,
 		),

--- a/go.mod
+++ b/go.mod
@@ -6,15 +6,15 @@ require (
 	github.com/go-logr/logr v1.4.1
 	github.com/google/uuid v1.6.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
-	github.com/onsi/ginkgo/v2 v2.14.0
-	github.com/onsi/gomega v1.30.0
+	github.com/onsi/ginkgo/v2 v2.15.0
+	github.com/onsi/gomega v1.31.1
 	github.com/openstack-k8s-operators/barbican-operator/api v0.0.0-00010101000000-000000000000
 	github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240219072823-a587b364203f
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240219094943-9bbb46c9afba
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240216173409-86913e6d5885
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240216173409-86913e6d5885
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240216173409-86913e6d5885
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240219072536-62f6b4dc7798
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3
 	go.uber.org/zap v1.26.0
 	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a
 	k8s.io/api v0.28.3

--- a/go.sum
+++ b/go.sum
@@ -85,10 +85,10 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/onsi/ginkgo/v2 v2.14.0 h1:vSmGj2Z5YPb9JwCWT6z6ihcUvDhuXLc3sJiqd3jMKAY=
-github.com/onsi/ginkgo/v2 v2.14.0/go.mod h1:JkUdW7JkN0V6rFvsHcJ478egV3XH9NxpD27Hal/PhZw=
-github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
-github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
+github.com/onsi/ginkgo/v2 v2.15.0 h1:79HwNRBAZHOEwrczrgSOPy+eFTTlIGELKy5as+ClttY=
+github.com/onsi/ginkgo/v2 v2.15.0/go.mod h1:HlxMHtYF57y6Dpf+mc5529KKmSq9h2FpCF+/ZkwUxKM=
+github.com/onsi/gomega v1.31.1 h1:KYppCUK+bUgAZwHOu7EXVBKyQA6ILvOESHkn/tgoqvo=
+github.com/onsi/gomega v1.31.1/go.mod h1:y40C95dwAD1Nz36SsEnxvfFe8FFfNxzI5eJ0EYGyAy0=
 github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 h1:rncLxJBpFGqBztyxCMwNRnMjhhIDOWHJowi6q8G6koI=
 github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240219072823-a587b364203f h1:suf/08227pC+qQRbsUPLMOSw3mJ82b0o9Hs7MO/g9BY=
@@ -103,8 +103,8 @@ github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.202402161
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240216173409-86913e6d5885/go.mod h1:sK82mkh2UzITsbNa/y6AKTZftHQnsYigqRx+rFbfZM4=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240216173409-86913e6d5885 h1:ioJ2MO3vAcBkLM+0UBu5IuKW/DPXcyiNSOLq0Xvn+Nw=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240216173409-86913e6d5885/go.mod h1:82nzS+DbBe1tzaMvNHH8FctmZzQ14ZAJysFGsMJiivo=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240219072536-62f6b4dc7798 h1:zL4DdQ5HPXCLHeRMAWC2zI7ypbkZVYg3UkyEFSnzeow=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240219072536-62f6b4dc7798/go.mod h1:PDqfLbP4ZWqQHAu1OtbjfpOGQUKSzLqRJChvE/9pcyQ=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3 h1:fwb+GvvnN9Mhkgg5pBksZ8W5+hLCcNOorHsUTQYA1Lg=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3/go.mod h1:f9IIyWeoskWoeWaDFF3qmAJ2Kqyovfi0Ar/QUfk3qag=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/barbican/const.go
+++ b/pkg/barbican/const.go
@@ -13,8 +13,17 @@ const (
 	ComponentWorker = "barbican-worker"
 	// ServiceType -
 	ServiceType = "key-manager"
-	// DatabaseName -
+
+	// DatabaseName - Name of the database used in CREATE DATABASE statement
 	DatabaseName = "barbican"
+
+	// DatabaseCRName - Name of the MariaDBDatabase CR
+	DatabaseCRName = "barbican"
+
+	// DatabaseUsernamePrefix - used by EnsureMariaDBAccount when a new username
+	// is to be generated, e.g. "barbican_e5a4", "barbican_78bc", etc
+	DatabaseUsernamePrefix = "barbican"
+
 	// BarbicanPublicPort -
 	BarbicanPublicPort int32 = 9311
 	// BarbicanInternalPort -

--- a/tests/functional/barbican_test_data.go
+++ b/tests/functional/barbican_test_data.go
@@ -20,6 +20,8 @@ package functional
 import (
 	"fmt"
 
+	"github.com/openstack-k8s-operators/barbican-operator/pkg/barbican"
+
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -40,7 +42,6 @@ const (
 
 // BarbicanTestData is the data structure used to provide input data to envTest
 type BarbicanTestData struct {
-	BarbicanDatabaseUser     string
 	BarbicanPassword         string
 	BarbicanServiceUser      string
 	ContainerImage           string
@@ -50,6 +51,8 @@ type BarbicanTestData struct {
 	RabbitmqSecretName       string
 	Instance                 types.NamespacedName
 	Barbican                 types.NamespacedName
+	BarbicanDatabaseName     types.NamespacedName
+	BarbicanDatabaseAccount  types.NamespacedName
 	BarbicanDBSync           types.NamespacedName
 	BarbicanAPI              types.NamespacedName
 	BarbicanRole             types.NamespacedName
@@ -80,6 +83,14 @@ func GetBarbicanTestData(barbicanName types.NamespacedName) BarbicanTestData {
 		Barbican: types.NamespacedName{
 			Namespace: barbicanName.Namespace,
 			Name:      barbicanName.Name,
+		},
+		BarbicanDatabaseName: types.NamespacedName{
+			Namespace: barbicanName.Namespace,
+			Name:      barbican.DatabaseCRName,
+		},
+		BarbicanDatabaseAccount: types.NamespacedName{
+			Namespace: barbicanName.Namespace,
+			Name:      "barbican",
 		},
 		BarbicanDBSync: types.NamespacedName{
 			Namespace: barbicanName.Namespace,
@@ -154,11 +165,10 @@ func GetBarbicanTestData(barbicanName types.NamespacedName) BarbicanTestData {
 			Namespace: barbicanName.Namespace,
 			Name:      PublicCertSecretName,
 		},
-		RabbitmqClusterName:  "rabbitmq",
-		RabbitmqSecretName:   "rabbitmq-secret",
-		BarbicanDatabaseUser: "barbican",
-		DatabaseInstance:     "openstack",
-		// Password used for both db and service
+		RabbitmqClusterName: "rabbitmq",
+		RabbitmqSecretName:  "rabbitmq-secret",
+		DatabaseInstance:    "openstack",
+		// Password used for service
 		BarbicanPassword:    "12345678",
 		BarbicanServiceUser: "barbican",
 		ContainerImage:      "test://barbican",

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -8,7 +8,7 @@ spec:
     [DEFAULT]
     debug = True
   databaseInstance: openstack
-  databaseUser: barbican
+  databaseAccount: barbican
   rabbitMqClusterName: rabbitmq
   barbicanAPI:
     replicas: 1

--- a/tests/kuttl/tests/barbican_tls/01-assert.yaml
+++ b/tests/kuttl/tests/barbican_tls/01-assert.yaml
@@ -13,7 +13,7 @@ spec:
     [DEFAULT]
     debug = True
   databaseInstance: openstack
-  databaseUser: barbican
+  databaseAccount: barbican
   rabbitMqClusterName: rabbitmq
   barbicanWorker:
     replicas: 1


### PR DESCRIPTION
…BAccountLead Jira: [OSPRH-4095](https://issues.redhat.com/browse/OSPRH-4095)

1. [x] controller calls EnsureMariaDBAccount up front to make sure MariaDBAccount is present
2. [x] error code from EnsureMariaDBAccount is handled, Conditions are amended when error is returned
3. [x] controller calls NewDatabaseForAccount instead of NewDatabase
4. [x]  GetAccountAndSecret is used to retrieve account /secret to populate template
5. [x]  GetDatabaseByName() , normally used for delete finalizers, replaced with GetDatabaseByNameAndAccount
6. [x]  CreateOrPatchAll() used to patch the Database, replacing CreateOrPatchDB / CreateOrPatchDBByName
7. [x]  controller calls DeleteUnusedMariaDBAccountFinalizers when launched pods are definitely running on a new MariaDBAccount, returns error code if present
8. [x]  PasswordSelectors that refer to database are removed
9. [x]  all databaseUser replaced with databaseAccount inside of all XYZ_types.go
10. [x] all databaseUser replaced with databaseAccount inside of all `kuttl/*.yaml`
11. [x] all default databaseUser names become databaseAccount, replacing underscores with dashes inside of all XYZ_types.go
12. [x] all default databaseUser names become databaseAccount, replacing underscores with dashes inside of all `kuttl/*.yaml`
13. [x] MariaDBAccountSuiteTests are used in controller ginkgo tests if it has them
14. [x] [184](https://github.com/openstack-k8s-operators/mariadb-operator/pull/184) is merged and replaces from go.mod are removed


