### PR TITLE
Remove deprecated annotation

### DIFF
--- a/config/manifests/bases/barbican-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/barbican-operator.clusterserviceversion.yaml
@@ -11,7 +11,6 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/operator-type: non-standalone
   name: barbican-operator.v0.0.0
   namespace: placeholder


### PR DESCRIPTION
This removes the operators.openshift.io/infrastructure-features annotation which has been deprecated [0].

[0]: https://github.com/openstack-k8s-operators/barbican-operator/pull/130#discussion_r1657438125