### PR TITLE
[OSPRH-9371] Fix VerifySecret so it requeues when necessary

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/onsi/ginkgo/v2 v2.19.1
 	github.com/onsi/gomega v1.34.1
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808054407-ac8a151e3cca
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808095747-579da98fa7a6
 	k8s.io/api v0.28.12
 	k8s.io/apimachinery v0.28.12
 	k8s.io/client-go v0.28.12

--- a/api/go.sum
+++ b/api/go.sum
@@ -68,8 +68,8 @@ github.com/onsi/ginkgo/v2 v2.19.1 h1:QXgq3Z8Crl5EL1WBAC98A5sEBHARrAJNzAmMxzLcRF0
 github.com/onsi/ginkgo/v2 v2.19.1/go.mod h1:O3DtEWQkPa/F7fBMgmZQKKsluAy8pd3rEQdrjkPb9zA=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808054407-ac8a151e3cca h1:ymNDlXtzuatPd+Oj+hL2YULEbKVsbHbytO+6HDoPwm4=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808054407-ac8a151e3cca/go.mod h1:hCT/Ba8kRkRB23d07YEsCzELsYcJGpD/Uw4NDh+LD6w=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808095747-579da98fa7a6 h1:QrqPZPnJuJoYRFXL3aE4b+onLjjEUq8b3JjuptUkOoE=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808095747-579da98fa7a6/go.mod h1:hCT/Ba8kRkRB23d07YEsCzELsYcJGpD/Uw4NDh+LD6w=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/openstack-k8s-operators/barbican-operator/api v0.0.0-00010101000000-000000000000
 	github.com/openstack-k8s-operators/infra-operator/apis v0.4.1-0.20240806064941-b443f719b8b7
 	github.com/openstack-k8s-operators/keystone-operator/api v0.4.1-0.20240806171358-1c577c9ef576
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808054407-ac8a151e3cca
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808095747-579da98fa7a6
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.4.1-0.20240808054407-ac8a151e3cca
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.4.1-0.20240808054407-ac8a151e3cca
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.4.1-0.20240806091527-f02e6eab246b

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/openstack-k8s-operators/infra-operator/apis v0.4.1-0.20240806064941-b
 github.com/openstack-k8s-operators/infra-operator/apis v0.4.1-0.20240806064941-b443f719b8b7/go.mod h1:dobs750SWnLGGP8Z1Y6Rn4uRU/a9PkKaklKlcE7kIVA=
 github.com/openstack-k8s-operators/keystone-operator/api v0.4.1-0.20240806171358-1c577c9ef576 h1:9XTSwNHHfjamTID0YMgK/Mb/x6oItdUl0OFXuUqGdIk=
 github.com/openstack-k8s-operators/keystone-operator/api v0.4.1-0.20240806171358-1c577c9ef576/go.mod h1:nAeWBizvWIMtbHEAzmIupqADriOF92V8MOox6doWupA=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808054407-ac8a151e3cca h1:ymNDlXtzuatPd+Oj+hL2YULEbKVsbHbytO+6HDoPwm4=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808054407-ac8a151e3cca/go.mod h1:hCT/Ba8kRkRB23d07YEsCzELsYcJGpD/Uw4NDh+LD6w=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808095747-579da98fa7a6 h1:QrqPZPnJuJoYRFXL3aE4b+onLjjEUq8b3JjuptUkOoE=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808095747-579da98fa7a6/go.mod h1:hCT/Ba8kRkRB23d07YEsCzELsYcJGpD/Uw4NDh+LD6w=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.4.1-0.20240808054407-ac8a151e3cca h1:KuNnvh3MEQ4tgG7X9k2wWC7uFVwE1lOqRBAaaJ0+WHQ=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.4.1-0.20240808054407-ac8a151e3cca/go.mod h1:Z9QhWZexP9fYcZrBRI5rrcRwTh6LSsd5XB7NWzdphaE=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.4.1-0.20240808054407-ac8a151e3cca h1:QCHc/473ywfiABLVSlhw5DEK6XpqH8tCdem88KRZXtA=


### PR DESCRIPTION
We've come to realize three things recently:

1. Returning an error to the reconciler along with a `RequeueAfter` will cause the reconciler to abandon the explicit requeue and only consider the error [1].
2. The `VerifySecret` function in `lib-common` was returning an error along with a requeue, thus contributing to the problem listed in item 1. [2]
3. Also, the error `VerifySecret` was returning was _not_ a "not found" error, but a generic k8s error -- so it wouldn't be properly handled by callers looking for a "not found" error. [3]

Now `VerifySecret` only returns a non-empty `ctrl.Result{}` if the `Secret` is missing, so let's handle that case in a separate if-clause. [4]

Jira: https://issues.redhat.com/browse/OSPRH-9371

[1] https://github.com/openstack-k8s-operators/keystone-operator/pull/459
[2] https://github.com/openstack-k8s-operators/lib-common/blob/ad3edb6e67ab738cfdbf4e2e78ac403784a08ab7/modules/common/secret/secret.go#L423-L425
[3] https://github.com/openstack-k8s-operators/lib-common/blob/ad3edb6e67ab738cfdbf4e2e78ac403784a08ab7/modules/common/secret/secret.go#L425
[4] https://github.com/openstack-k8s-operators/lib-common/blob/579da98fa7a62b70b43cdba92e82d6497afe8835/modules/common/secret/secret.go#L425-L427