### PR TITLE
Adding nodeSelector functionality

### DIFF
--- a/controllers/barbican_controller.go
+++ b/controllers/barbican_controller.go
@@ -724,7 +724,7 @@ func (r *BarbicanReconciler) workerDeploymentCreateOrUpdate(ctx context.Context,
 	}
 
 	// If NodeSelector is not specified in BarbicanWorkerTemplate, the current
-	// Worker instance inherits the valur from the top-level CR.
+	// Worker instance inherits the value from the top-level CR.
 	if workerSpec.BarbicanWorkerTemplate.BarbicanWorkerTemplateCore.BarbicanComponentTemplate.NodeSelector == nil {
 		workerSpec.BarbicanWorkerTemplate.BarbicanWorkerTemplateCore.BarbicanComponentTemplate.NodeSelector = instance.Spec.BarbicanSpecBase.NodeSelector
 	}

--- a/controllers/barbican_controller.go
+++ b/controllers/barbican_controller.go
@@ -680,7 +680,7 @@ func (r *BarbicanReconciler) apiDeploymentCreateOrUpdate(ctx context.Context, in
 	}
 
 	// If NodeSelector is not specified in BarbicanAPITemplate, the current
-	// API instance inherits the valur from the top-level CR.
+	// API instance inherits the value from the top-level CR.
 	if apiSpec.BarbicanAPITemplate.BarbicanAPITemplateCore.BarbicanComponentTemplate.NodeSelector == nil {
 		apiSpec.BarbicanAPITemplate.BarbicanAPITemplateCore.BarbicanComponentTemplate.NodeSelector = instance.Spec.BarbicanSpecBase.NodeSelector
 	}

--- a/controllers/barbican_controller.go
+++ b/controllers/barbican_controller.go
@@ -679,6 +679,12 @@ func (r *BarbicanReconciler) apiDeploymentCreateOrUpdate(ctx context.Context, in
 		TransportURLSecret:  instance.Status.TransportURLSecret,
 	}
 
+	// If NodeSelector is not specified in BarbicanAPITemplate, the current
+	// API instance inherits the valur from the top-level CR.
+	if apiSpec.BarbicanAPITemplate.BarbicanAPITemplateCore.BarbicanComponentTemplate.NodeSelector == nil {
+		apiSpec.BarbicanAPITemplate.BarbicanAPITemplateCore.BarbicanComponentTemplate.NodeSelector = instance.Spec.BarbicanSpecBase.NodeSelector
+	}
+
 	deployment := &barbicanv1beta1.BarbicanAPI{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-api", instance.Name),
@@ -717,6 +723,12 @@ func (r *BarbicanReconciler) workerDeploymentCreateOrUpdate(ctx context.Context,
 		TLS:                    instance.Spec.BarbicanAPI.TLS.Ca,
 	}
 
+	// If NodeSelector is not specified in BarbicanWorkerTemplate, the current
+	// Worker instance inherits the valur from the top-level CR.
+	if workerSpec.BarbicanWorkerTemplate.BarbicanWorkerTemplateCore.BarbicanComponentTemplate.NodeSelector == nil {
+		workerSpec.BarbicanWorkerTemplate.BarbicanWorkerTemplateCore.BarbicanComponentTemplate.NodeSelector = instance.Spec.BarbicanSpecBase.NodeSelector
+	}
+
 	deployment := &barbicanv1beta1.BarbicanWorker{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-worker", instance.Name),
@@ -752,6 +764,12 @@ func (r *BarbicanReconciler) keystoneListenerDeploymentCreateOrUpdate(ctx contex
 		DatabaseHostname:                 instance.Status.DatabaseHostname,
 		TransportURLSecret:               instance.Status.TransportURLSecret,
 		TLS:                              instance.Spec.BarbicanAPI.TLS.Ca,
+	}
+
+	// If NodeSelector is not specified in BarbicanKeystoneListenerTemplate, the current
+	// KeystoneListener instance inherits the valur from the top-level CR.
+	if keystoneListenerSpec.BarbicanKeystoneListenerTemplate.BarbicanKeystoneListenerTemplateCore.BarbicanComponentTemplate.NodeSelector == nil {
+		keystoneListenerSpec.BarbicanKeystoneListenerTemplate.BarbicanKeystoneListenerTemplateCore.BarbicanComponentTemplate.NodeSelector = instance.Spec.BarbicanSpecBase.NodeSelector
 	}
 
 	deployment := &barbicanv1beta1.BarbicanKeystoneListener{

--- a/controllers/barbican_controller.go
+++ b/controllers/barbican_controller.go
@@ -767,7 +767,7 @@ func (r *BarbicanReconciler) keystoneListenerDeploymentCreateOrUpdate(ctx contex
 	}
 
 	// If NodeSelector is not specified in BarbicanKeystoneListenerTemplate, the current
-	// KeystoneListener instance inherits the valur from the top-level CR.
+	// KeystoneListener instance inherits the value from the top-level CR.
 	if keystoneListenerSpec.BarbicanKeystoneListenerTemplate.BarbicanKeystoneListenerTemplateCore.BarbicanComponentTemplate.NodeSelector == nil {
 		keystoneListenerSpec.BarbicanKeystoneListenerTemplate.BarbicanKeystoneListenerTemplateCore.BarbicanComponentTemplate.NodeSelector = instance.Spec.BarbicanSpecBase.NodeSelector
 	}

--- a/pkg/barbicanapi/deployment.go
+++ b/pkg/barbicanapi/deployment.go
@@ -128,6 +128,7 @@ func Deployment(
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: instance.Spec.ServiceAccount,
+					NodeSelector:       instance.Spec.NodeSelector,
 					Containers: []corev1.Container{
 						{
 							Name: instance.Name + "-log",
@@ -176,6 +177,7 @@ func Deployment(
 			},
 		},
 	}
+
 	deployment.Spec.Template.Spec.Volumes = append(barbican.GetVolumes(
 		instance.Name,
 		instance.Spec.CustomServiceConfigSecrets),

--- a/pkg/barbicankeystonelistener/deployment.go
+++ b/pkg/barbicankeystonelistener/deployment.go
@@ -80,6 +80,7 @@ func Deployment(
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: instance.Spec.ServiceAccount,
+					NodeSelector:       instance.Spec.NodeSelector,
 					Containers: []corev1.Container{
 						{
 							Name: instance.Name + "-log",

--- a/pkg/barbicanworker/deployment.go
+++ b/pkg/barbicanworker/deployment.go
@@ -104,6 +104,7 @@ func Deployment(
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: instance.Spec.ServiceAccount,
+					NodeSelector:       instance.Spec.NodeSelector,
 					Containers: []corev1.Container{
 						{
 							Name: instance.Name + "-log",

--- a/tests/kuttl/tests/barbican_scale/02-assert.yaml
+++ b/tests/kuttl/tests/barbican_scale/02-assert.yaml
@@ -25,7 +25,6 @@ metadata:
 spec:
   replicas: 2
 status:
-  availableReplicas: 2
   replicas: 2
 ---
 apiVersion: apps/v1
@@ -35,7 +34,6 @@ metadata:
 spec:
   replicas: 2
 status:
-  availableReplicas: 2
   replicas: 2
 ---
 apiVersion: apps/v1
@@ -45,5 +43,4 @@ metadata:
 spec:
   replicas: 2
 status:
-  availableReplicas: 2
   replicas: 2

--- a/tests/kuttl/tests/barbican_scale/03-assert.yaml
+++ b/tests/kuttl/tests/barbican_scale/03-assert.yaml
@@ -25,7 +25,6 @@ metadata:
 spec:
   replicas: 1
 status:
-  availableReplicas: 1
   replicas: 1
 ---
 apiVersion: apps/v1
@@ -35,7 +34,6 @@ metadata:
 spec:
   replicas: 1
 status:
-  availableReplicas: 1
   replicas: 1
 ---
 apiVersion: apps/v1
@@ -45,5 +43,4 @@ metadata:
 spec:
   replicas: 1
 status:
-  availableReplicas: 1
   replicas: 1


### PR DESCRIPTION
The previous Barbican operator's code was not taking actions when the `nodeSelector` attribute was specified in the control plane. This patch addresses the missing part.