### PR TITLE
[sample] comment optional nodeSelector

### DIFF
--- a/config/samples/barbican_v1beta1_barbican.yaml
+++ b/config/samples/barbican_v1beta1_barbican.yaml
@@ -20,8 +20,8 @@ spec:
     service: BarbicanPassword
     simplecryptokek: BarbicanSimpleCryptoKEK
   preserveJobs: true
-  nodeSelector:
-    node: controller
+#  nodeSelector:
+#    node: controller
   customServiceConfig: |
     [DEFAULT]
     debug = True
@@ -29,8 +29,8 @@ spec:
     policy.json: |
       {"some": "custom policy"}
   barbicanAPI:
-    nodeSelector:
-      optional_override: here
+#    nodeSelector:
+#      optional_override: here
     customServiceConfig: |
       [optional]
       overrides = True
@@ -41,8 +41,8 @@ spec:
       database: BarbicanDatabasePassword
       service: BarbicanPassword
   barbicanWorker:
-    nodeSelector:
-      optional_override: here
+#    nodeSelector:
+#      optional_override: here
     customServiceConfig: |
       [optional]
       overrides = True
@@ -50,8 +50,8 @@ spec:
       optional_policy.json: |
         {"some": "custom policy"}
   barbicanKeystoneListener:
-    nodeSelector:
-      optional_override: here
+#    nodeSelector:
+#      optional_override: here
     customServiceConfig: |
       [optional]
       overrides = True

--- a/config/samples/tls-e/barbican_v1beta1_barbican.yaml
+++ b/config/samples/tls-e/barbican_v1beta1_barbican.yaml
@@ -19,8 +19,8 @@ spec:
     database: BarbicanDatabasePassword
     service: BarbicanPassword
   preserveJobs: true
-  nodeSelector:
-    node: controller
+#  nodeSelector:
+#    node: controller
   customServiceConfig: |
     [DEFAULT]
     debug = True
@@ -28,8 +28,8 @@ spec:
     policy.json: |
       {"some": "custom policy"}
   barbicanAPI:
-    nodeSelector:
-      optional_override: here
+#    nodeSelector:
+#      optional_override: here
     customServiceConfig: |
       [optional]
       overrides = True
@@ -47,8 +47,8 @@ spec:
           secretName: cert-barbican-public-svc
       caBundleSecretName: combined-ca-bundle
   barbicanWorker:
-    nodeSelector:
-      optional_override: here
+#    nodeSelector:
+#      optional_override: here
     customServiceConfig: |
       [optional]
       overrides = True
@@ -56,8 +56,8 @@ spec:
       optional_policy.json: |
         {"some": "custom policy"}
   barbicanKeystoneListener:
-    nodeSelector:
-      optional_override: here
+#    nodeSelector:
+#      optional_override: here
     customServiceConfig: |
       [optional]
       overrides = True


### PR DESCRIPTION
When other services deploy barbican as a dependency in CI using the barbican sample the nodeselector functionality, which was added recently with
https://github.com/openstack-k8s-operators/barbican-operator/pull/153 prevents the pods from being able to be scheduled. Therefore this change will comment these optional settings.