### PR TITLE
Fix CustomServiceConfig barbican configuration

### DIFF
--- a/api/bases/barbican.openstack.org_barbicanapis.yaml
+++ b/api/bases/barbican.openstack.org_barbicanapis.yaml
@@ -43,8 +43,8 @@ spec:
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets
-                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
-                  file.
+                  added to to /etc/<service>/<service>.conf.d directory as a custom
+                  config file.
                 type: string
               customServiceConfigSecrets:
                 description: CustomServiceConfigSecrets - customize the service config

--- a/api/bases/barbican.openstack.org_barbicankeystonelisteners.yaml
+++ b/api/bases/barbican.openstack.org_barbicankeystonelisteners.yaml
@@ -45,8 +45,8 @@ spec:
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets
-                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
-                  file.
+                  added to to /etc/<service>/<service>.conf.d directory as a custom
+                  config file.
                 type: string
               customServiceConfigSecrets:
                 description: CustomServiceConfigSecrets - customize the service config

--- a/api/bases/barbican.openstack.org_barbicanworkers.yaml
+++ b/api/bases/barbican.openstack.org_barbicanworkers.yaml
@@ -43,8 +43,8 @@ spec:
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets
-                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
-                  file.
+                  added to to /etc/<service>/<service>.conf.d directory as a custom
+                  config file.
                 type: string
               customServiceConfigSecrets:
                 description: CustomServiceConfigSecrets - customize the service config

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -46,12 +46,6 @@ type BarbicanTemplate struct {
 	// PasswordSelectors - Selectors to identify the ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
-	// +kubebuilder:validation:Optional
-	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
-	// or overwrite rendered information using raw OpenStack config format. The content gets added to
-	// to /etc/<service>/<service>.conf.d directory as custom.conf file.
-	CustomServiceConfig string `json:"customServiceConfig,omitempty"`
-
 	// +kubebuilder:validation:Required
 	// ServiceAccount - service account name used internally to provide Barbican services the default SA name
 	ServiceAccount string `json:"serviceAccount"`

--- a/config/crd/bases/barbican.openstack.org_barbicanapis.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicanapis.yaml
@@ -43,8 +43,8 @@ spec:
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets
-                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
-                  file.
+                  added to to /etc/<service>/<service>.conf.d directory as a custom
+                  config file.
                 type: string
               customServiceConfigSecrets:
                 description: CustomServiceConfigSecrets - customize the service config

--- a/config/crd/bases/barbican.openstack.org_barbicankeystonelisteners.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicankeystonelisteners.yaml
@@ -45,8 +45,8 @@ spec:
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets
-                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
-                  file.
+                  added to to /etc/<service>/<service>.conf.d directory as a custom
+                  config file.
                 type: string
               customServiceConfigSecrets:
                 description: CustomServiceConfigSecrets - customize the service config

--- a/config/crd/bases/barbican.openstack.org_barbicanworkers.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicanworkers.yaml
@@ -43,8 +43,8 @@ spec:
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets
-                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
-                  file.
+                  added to to /etc/<service>/<service>.conf.d directory as a custom
+                  config file.
                 type: string
               customServiceConfigSecrets:
                 description: CustomServiceConfigSecrets - customize the service config

--- a/controllers/barbicanapi_controller.go
+++ b/controllers/barbicanapi_controller.go
@@ -271,8 +271,8 @@ func (r *BarbicanAPIReconciler) generateServiceConfigs(
 	}
 	// customData hold any customization for the service.
 	customData := map[string]string{
-		common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig,
-		"my.cnf":                           db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
+		barbican.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig,
+		"my.cnf":                             db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
 	}
 
 	for key, data := range instance.Spec.DefaultConfigOverwrite {

--- a/controllers/barbicankeystonelistener_controller.go
+++ b/controllers/barbicankeystonelistener_controller.go
@@ -252,8 +252,8 @@ func (r *BarbicanKeystoneListenerReconciler) generateServiceConfigs(
 	}
 	// customData hold any customization for the service.
 	customData := map[string]string{
-		common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig,
-		"my.cnf":                           db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
+		barbican.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig,
+		"my.cnf":                             db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
 	}
 	Log.Info(fmt.Sprintf("[KeystoneListener] instance type %s", instance.GetObjectKind().GroupVersionKind().Kind))
 

--- a/controllers/barbicanworker_controller.go
+++ b/controllers/barbicanworker_controller.go
@@ -241,8 +241,8 @@ func (r *BarbicanWorkerReconciler) generateServiceConfigs(
 	}
 	// customData hold any customization for the service.
 	customData := map[string]string{
-		common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig,
-		"my.cnf":                           db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
+		barbican.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig,
+		"my.cnf":                             db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
 	}
 
 	Log.Info(fmt.Sprintf("[Worker] instance type %s", instance.GetObjectKind().GroupVersionKind().Kind))

--- a/pkg/barbican/const.go
+++ b/pkg/barbican/const.go
@@ -33,9 +33,9 @@ const (
 	// CustomConfigFileName -
 	CustomConfigFileName = "01-custom.conf"
 	// CustomServiceConfigFileName -
-	CustomServiceConfigFileName = "02-service.conf"
+	CustomServiceConfigFileName = "02-service-custom.conf"
 	// CustomServiceConfigSecretsFileName -
-	CustomServiceConfigSecretsFileName = "03-secrets.conf"
+	CustomServiceConfigSecretsFileName = "03-secrets-custom.conf"
 	// BarbicanAPI defines the barbican-api group
 	BarbicanAPI storage.PropagationType = "BarbicanAPI"
 	// BarbicanWorker defines the barbican-worker group

--- a/templates/barbican/config/barbican-api-config.json
+++ b/templates/barbican/config/barbican-api-config.json
@@ -8,15 +8,15 @@
       "perm": "0600"
     },
     {
-      "source": "/var/lib/config-data/default/02-service.conf",
-      "dest": "/etc/barbican/barbican.conf.d/02-service.conf",
+      "source": "/var/lib/config-data/default/02-service-custom.conf",
+      "dest": "/etc/barbican/barbican.conf.d/custom.conf",
       "owner": "barbican",
       "perm": "0600",
       "optional": true
     },
     {
-      "source": "/var/lib/config-data/default/03-secrets.conf",
-      "dest": "/etc/barbican/barbican.conf.d/03-secrets.conf",
+      "source": "/var/lib/config-data/default/03-secrets-custom.conf",
+      "dest": "/etc/barbican/barbican.conf.d/03-secrets-custom.conf",
       "owner": "barbican",
       "perm": "0640",
       "optional": true

--- a/templates/barbican/config/barbican-keystone-listener-config.json
+++ b/templates/barbican/config/barbican-keystone-listener-config.json
@@ -8,15 +8,15 @@
         "perm": "0600"
       },
       {
-        "source": "/var/lib/config-data/default/02-service.conf",
-        "dest": "/etc/barbican/barbican.conf.d/02-service.conf",
+        "source": "/var/lib/config-data/default/02-service-custom.conf",
+        "dest": "/etc/barbican/barbican.conf.d/custom.conf",
         "owner": "barbican",
         "perm": "0600",
         "optional": true
       },
       {
-        "source": "/var/lib/config-data/default/03-secrets.conf",
-        "dest": "/etc/barbican/barbican.conf.d/03-secrets.conf",
+        "source": "/var/lib/config-data/default/03-secrets-custom.conf",
+        "dest": "/etc/barbican/barbican.conf.d/03-secrets-custom.conf",
         "owner": "barbican",
         "perm": "0640",
         "optional": true

--- a/templates/barbican/config/barbican-worker-config.json
+++ b/templates/barbican/config/barbican-worker-config.json
@@ -8,15 +8,15 @@
         "perm": "0600"
       },
       {
-        "source": "/var/lib/config-data/default/02-service.conf",
-        "dest": "/etc/barbican/barbican.conf.d/02-service.conf",
+        "source": "/var/lib/config-data/default/02-service-custom.conf",
+        "dest": "/etc/barbican/barbican.conf.d/custom.conf",
         "owner": "barbican",
         "perm": "0600",
         "optional": true
       },
       {
-        "source": "/var/lib/config-data/default/03-secrets.conf",
-        "dest": "/etc/barbican/barbican.conf.d/03-secrets.conf",
+        "source": "/var/lib/config-data/default/03-secrets-custom.conf",
+        "dest": "/etc/barbican/barbican.conf.d/03-secrets-custom.conf",
         "owner": "barbican",
         "perm": "0640",
         "optional": true


### PR DESCRIPTION
This PR adds support for the `CustomServiceConfig` field in the Barbican CRD, allowing custom configurations for the Barbican API, worker, and keystone-listener services.

Example:
```yaml
barbican:
  template:
    databaseInstance: openstack
    secret: osp-secret
    barbicanAPI:
      customServiceConfig: |
        [DEFAULT]
        max_allowed_secret_in_bytes = 1048576
      replicas: 1
 ```

The custom config file is now mounted as a  `02-service-custom.conf` file to `/var/lib/config-data/default/`  location and copied to `/etc/barbican/barbican.conf.d/` as a `custom.conf` file.