### PR TITLE
Ensure nodeSelector logic is consistent for all operators

### DIFF
--- a/api/v1beta1/barbican_types.go
+++ b/api/v1beta1/barbican_types.go
@@ -72,7 +72,7 @@ type BarbicanSpecBase struct {
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this component. Setting here overrides
 	// any global NodeSelector settings within the Barbican CR.
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -64,7 +64,7 @@ type BarbicanComponentTemplate struct {
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this component. Setting here overrides
 	// any global NodeSelector settings within the Barbican CR.
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=1

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -242,9 +242,13 @@ func (in *BarbicanComponentTemplate) DeepCopyInto(out *BarbicanComponentTemplate
 	*out = *in
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		*out = new(map[string]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]string, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
 		}
 	}
 	if in.Replicas != nil {
@@ -507,9 +511,13 @@ func (in *BarbicanSpecBase) DeepCopyInto(out *BarbicanSpecBase) {
 	out.BarbicanTemplate = in.BarbicanTemplate
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		*out = new(map[string]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]string, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
 		}
 	}
 	if in.DefaultConfigOverwrite != nil {

--- a/controllers/barbican_controller.go
+++ b/controllers/barbican_controller.go
@@ -681,8 +681,8 @@ func (r *BarbicanReconciler) apiDeploymentCreateOrUpdate(ctx context.Context, in
 
 	// If NodeSelector is not specified in BarbicanAPITemplate, the current
 	// API instance inherits the value from the top-level CR.
-	if apiSpec.BarbicanAPITemplate.BarbicanAPITemplateCore.BarbicanComponentTemplate.NodeSelector == nil {
-		apiSpec.BarbicanAPITemplate.BarbicanAPITemplateCore.BarbicanComponentTemplate.NodeSelector = instance.Spec.BarbicanSpecBase.NodeSelector
+	if apiSpec.NodeSelector == nil {
+		apiSpec.NodeSelector = instance.Spec.NodeSelector
 	}
 
 	deployment := &barbicanv1beta1.BarbicanAPI{
@@ -725,8 +725,8 @@ func (r *BarbicanReconciler) workerDeploymentCreateOrUpdate(ctx context.Context,
 
 	// If NodeSelector is not specified in BarbicanWorkerTemplate, the current
 	// Worker instance inherits the value from the top-level CR.
-	if workerSpec.BarbicanWorkerTemplate.BarbicanWorkerTemplateCore.BarbicanComponentTemplate.NodeSelector == nil {
-		workerSpec.BarbicanWorkerTemplate.BarbicanWorkerTemplateCore.BarbicanComponentTemplate.NodeSelector = instance.Spec.BarbicanSpecBase.NodeSelector
+	if workerSpec.NodeSelector == nil {
+		workerSpec.NodeSelector = instance.Spec.NodeSelector
 	}
 
 	deployment := &barbicanv1beta1.BarbicanWorker{
@@ -768,8 +768,8 @@ func (r *BarbicanReconciler) keystoneListenerDeploymentCreateOrUpdate(ctx contex
 
 	// If NodeSelector is not specified in BarbicanKeystoneListenerTemplate, the current
 	// KeystoneListener instance inherits the value from the top-level CR.
-	if keystoneListenerSpec.BarbicanKeystoneListenerTemplate.BarbicanKeystoneListenerTemplateCore.BarbicanComponentTemplate.NodeSelector == nil {
-		keystoneListenerSpec.BarbicanKeystoneListenerTemplate.BarbicanKeystoneListenerTemplateCore.BarbicanComponentTemplate.NodeSelector = instance.Spec.BarbicanSpecBase.NodeSelector
+	if keystoneListenerSpec.NodeSelector == nil {
+		keystoneListenerSpec.NodeSelector = instance.Spec.NodeSelector
 	}
 
 	deployment := &barbicanv1beta1.BarbicanKeystoneListener{

--- a/pkg/barbican/dbsync.go
+++ b/pkg/barbican/dbsync.go
@@ -114,5 +114,9 @@ func DbSyncJob(instance *barbicanv1beta1.Barbican, labels map[string]string, ann
 		dbSyncVolume...,
 	)
 
+	if instance.Spec.NodeSelector != nil {
+		job.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
+	}
+
 	return job
 }

--- a/pkg/barbicanapi/deployment.go
+++ b/pkg/barbicanapi/deployment.go
@@ -128,7 +128,6 @@ func Deployment(
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: instance.Spec.ServiceAccount,
-					NodeSelector:       instance.Spec.NodeSelector,
 					Containers: []corev1.Container{
 						{
 							Name: instance.Name + "-log",
@@ -182,6 +181,10 @@ func Deployment(
 		instance.Name,
 		instance.Spec.CustomServiceConfigSecrets),
 		apiVolumes...)
+
+	if instance.Spec.NodeSelector != nil {
+		deployment.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
+	}
 
 	return deployment, nil
 }

--- a/pkg/barbicankeystonelistener/deployment.go
+++ b/pkg/barbicankeystonelistener/deployment.go
@@ -80,7 +80,6 @@ func Deployment(
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: instance.Spec.ServiceAccount,
-					NodeSelector:       instance.Spec.NodeSelector,
 					Containers: []corev1.Container{
 						{
 							Name: instance.Name + "-log",
@@ -129,5 +128,10 @@ func Deployment(
 		instance.Name,
 		instance.Spec.CustomServiceConfigSecrets),
 		keystoneListenerVolumes...)
+
+	if instance.Spec.NodeSelector != nil {
+		deployment.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
+	}
+
 	return deployment
 }

--- a/pkg/barbicanworker/deployment.go
+++ b/pkg/barbicanworker/deployment.go
@@ -104,7 +104,6 @@ func Deployment(
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: instance.Spec.ServiceAccount,
-					NodeSelector:       instance.Spec.NodeSelector,
 					Containers: []corev1.Container{
 						{
 							Name: instance.Name + "-log",
@@ -157,5 +156,10 @@ func Deployment(
 		instance.Name,
 		instance.Spec.CustomServiceConfigSecrets),
 		workerVolumes...)
+
+	if instance.Spec.NodeSelector != nil {
+		deployment.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
+	}
+
 	return deployment
 }


### PR DESCRIPTION
nodeSelectors are not currently applied consistently across all operators.

Some do not support nodeSelectors at all - will be implemented in this series of pull requests.
Some do not apply them to every pod (jobs/cronjobs esp) - will be resolved in this series of pull requests.
Some do not apply a node selector update correctly, only when not initially set.
Some support nodeSelectors but do not inherit the default nodeSelector from the OpenstackControlPlane CR.

Jira: [OSPRH-10734](https://issues.redhat.com//browse/OSPRH-10734)