### PR TITLE
Update the route timeout webhook reference

### DIFF
--- a/api/v1beta1/barbican_webhook.go
+++ b/api/v1beta1/barbican_webhook.go
@@ -229,7 +229,7 @@ func (spec *BarbicanSpecCore) GetDefaultRouteAnnotations() (annotations map[stri
 }
 
 // SetDefaultRouteAnnotations sets HAProxy timeout values for Barbican API routes
-func (spec *BarbicanAPITemplateCore) SetDefaultRouteAnnotations(annotations map[string]string) {
+func (spec *BarbicanSpecCore) SetDefaultRouteAnnotations(annotations map[string]string) {
 	const haProxyAnno = "haproxy.router.openshift.io/timeout"
 	// Use a custom annotation to flag when the operator has set the default HAProxy timeout
 	// With the annotation func determines when to overwrite existing HAProxy timeout with the APITimeout


### PR DESCRIPTION
Update SetDefaultRouteAnnotations(..) to use *BarbicanSpecCore instead of *BarbicanAPITemplateCore to correctly reference the timeout setting.

Previously, the webhook in openstack-operator was incorrectly using the BarbicanAPI timeout (set to 0), instead of the Barbican timeout, which takes precedence. This caused the route timeout to be set incorrectly.

In openstack-operator we can then use: `r.Spec.Barbican.Template.SetDefaultRouteAnnotations(r.Spec.Barbican.APIOverride.Route.Annotations)`

instead of:
`r.Spec.Barbican.Template.BarbicanAPI.SetDefaultRouteAnnotations(r.Spec.Barbican.APIOverride.Route.Annotations)`

Which was referencing incorrect timeout.

Jira: https://issues.redhat.com/browse/OSPRH-10964
