### PR TITLE
Fix generate_pkcs11_keys.sh to handle quotes

### DIFF
--- a/templates/barbican/bin/generate_pkcs11_keys.sh
+++ b/templates/barbican/bin/generate_pkcs11_keys.sh
@@ -17,11 +17,11 @@ set -xe
 
 {{- if and (index . "PKCS11Enabled") .PKCS11Enabled }}
 
-mkek_label=$(crudini --get /etc/barbican/barbican.conf.d/01-custom.conf p11_crypto_plugin mkek_label)
+eval mkek_label=$(crudini --get /etc/barbican/barbican.conf.d/01-custom.conf p11_crypto_plugin mkek_label)
 echo "Creating  MKEK label $mkek_label"
 barbican-manage hsm check_mkek --label $mkek_label || barbican-manage hsm gen_mkek --label $mkek_label
 
-hmac_label=$(crudini --get /etc/barbican/barbican.conf.d/01-custom.conf p11_crypto_plugin hmac_label)
+eval hmac_label=$(crudini --get /etc/barbican/barbican.conf.d/01-custom.conf p11_crypto_plugin hmac_label)
 echo "Creating  HMAC label $hmac_label"
 barbican-manage hsm check_hmac --label $hmac_label || barbican-manage hsm gen_hmac --label $hmac_label
 {{- end }}


### PR DESCRIPTION
Right now, generate_pkcs11_keys.sh will read from the config and take the value of the mkek and hmac labels as-is, without removing any quotes.  So, if the config file has quotes around the value, like "foo", the key "foo" (with quotes) will be created.

Of course, when barbican-api comes up, it strips the quotes and starts looking for key foo(and cannot find it).

This fixes the problem by stripping quotes from the value in the script.