### PR TITLE
Consume Topology CR by reference

### DIFF
--- a/api/bases/barbican.openstack.org_barbicanapis.yaml
+++ b/api/bases/barbican.openstack.org_barbicanapis.yaml
@@ -446,6 +446,23 @@ spec:
                       bundle file
                     type: string
                 type: object
+              topologyRef:
+                description: |-
+                  TopologyRef to apply the Topology defined by the associated CR referenced
+                  by name
+                properties:
+                  name:
+                    description: Name - The Topology CR name that the Service references
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace - The Namespace to fetch the Topology CR referenced
+                      NOTE: Namespace currently points by default to the same namespace where
+                      the Service is deployed. Customizing the namespace is not supported and
+                      webhooks prevent editing this field to a value different from the
+                      current project
+                    type: string
+                type: object
               transportURLSecret:
                 description: TransportURLSecret - Secret containing RabbitMQ transportURL
                 type: string
@@ -514,6 +531,9 @@ spec:
                   type: string
                 description: Map of hashes to track e.g. job status
                 type: object
+              lastAppliedTopology:
+                description: LastAppliedTopology - the last applied Topology
+                type: string
               networkAttachments:
                 additionalProperties:
                   items:

--- a/api/bases/barbican.openstack.org_barbicankeystonelisteners.yaml
+++ b/api/bases/barbican.openstack.org_barbicankeystonelisteners.yaml
@@ -258,6 +258,23 @@ spec:
                       bundle file
                     type: string
                 type: object
+              topologyRef:
+                description: |-
+                  TopologyRef to apply the Topology defined by the associated CR referenced
+                  by name
+                properties:
+                  name:
+                    description: Name - The Topology CR name that the Service references
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace - The Namespace to fetch the Topology CR referenced
+                      NOTE: Namespace currently points by default to the same namespace where
+                      the Service is deployed. Customizing the namespace is not supported and
+                      webhooks prevent editing this field to a value different from the
+                      current project
+                    type: string
+                type: object
               transportURLSecret:
                 type: string
             required:
@@ -321,6 +338,9 @@ spec:
                   type: string
                 description: Map of hashes to track e.g. job status
                 type: object
+              lastAppliedTopology:
+                description: LastAppliedTopology - the last applied Topology
+                type: string
               networkAttachments:
                 additionalProperties:
                   items:

--- a/api/bases/barbican.openstack.org_barbicans.yaml
+++ b/api/bases/barbican.openstack.org_barbicans.yaml
@@ -356,6 +356,24 @@ spec:
                           a pre-created bundle file
                         type: string
                     type: object
+                  topologyRef:
+                    description: |-
+                      TopologyRef to apply the Topology defined by the associated CR referenced
+                      by name
+                    properties:
+                      name:
+                        description: Name - The Topology CR name that the Service
+                          references
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace - The Namespace to fetch the Topology CR referenced
+                          NOTE: Namespace currently points by default to the same namespace where
+                          the Service is deployed. Customizing the namespace is not supported and
+                          webhooks prevent editing this field to a value different from the
+                          current project
+                        type: string
+                    type: object
                 required:
                 - containerImage
                 type: object
@@ -466,6 +484,24 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  topologyRef:
+                    description: |-
+                      TopologyRef to apply the Topology defined by the associated CR referenced
+                      by name
+                    properties:
+                      name:
+                        description: Name - The Topology CR name that the Service
+                          references
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace - The Namespace to fetch the Topology CR referenced
+                          NOTE: Namespace currently points by default to the same namespace where
+                          the Service is deployed. Customizing the namespace is not supported and
+                          webhooks prevent editing this field to a value different from the
+                          current project
+                        type: string
+                    type: object
                 required:
                 - containerImage
                 type: object
@@ -575,6 +611,24 @@ spec:
                           otherwise to an implementation-defined value. Requests cannot exceed Limits.
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
+                    type: object
+                  topologyRef:
+                    description: |-
+                      TopologyRef to apply the Topology defined by the associated CR referenced
+                      by name
+                    properties:
+                      name:
+                        description: Name - The Topology CR name that the Service
+                          references
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace - The Namespace to fetch the Topology CR referenced
+                          NOTE: Namespace currently points by default to the same namespace where
+                          the Service is deployed. Customizing the namespace is not supported and
+                          webhooks prevent editing this field to a value different from the
+                          current project
+                        type: string
                     type: object
                 required:
                 - containerImage
@@ -700,6 +754,23 @@ spec:
                 description: Secret containing the Key Encryption Key (KEK) used for
                   the Simple Crypto backend
                 type: string
+              topologyRef:
+                description: |-
+                  TopologyRef to apply the Topology defined by the associated CR referenced
+                  by name
+                properties:
+                  name:
+                    description: Name - The Topology CR name that the Service references
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace - The Namespace to fetch the Topology CR referenced
+                      NOTE: Namespace currently points by default to the same namespace where
+                      the Service is deployed. Customizing the namespace is not supported and
+                      webhooks prevent editing this field to a value different from the
+                      current project
+                    type: string
+                type: object
             required:
             - barbicanAPI
             - barbicanKeystoneListener

--- a/api/bases/barbican.openstack.org_barbicanworkers.yaml
+++ b/api/bases/barbican.openstack.org_barbicanworkers.yaml
@@ -256,6 +256,23 @@ spec:
                       bundle file
                     type: string
                 type: object
+              topologyRef:
+                description: |-
+                  TopologyRef to apply the Topology defined by the associated CR referenced
+                  by name
+                properties:
+                  name:
+                    description: Name - The Topology CR name that the Service references
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace - The Namespace to fetch the Topology CR referenced
+                      NOTE: Namespace currently points by default to the same namespace where
+                      the Service is deployed. Customizing the namespace is not supported and
+                      webhooks prevent editing this field to a value different from the
+                      current project
+                    type: string
+                type: object
               transportURLSecret:
                 type: string
             required:
@@ -318,6 +335,9 @@ spec:
                   type: string
                 description: Map of hashes to track e.g. job status
                 type: object
+              lastAppliedTopology:
+                description: LastAppliedTopology - the last applied Topology
+                type: string
               networkAttachments:
                 additionalProperties:
                   items:

--- a/api/go.mod
+++ b/api/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/onsi/ginkgo/v2 v2.20.1
 	github.com/onsi/gomega v1.34.1
+	github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250204091142-ae8379c31edb
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.5.1-0.20250205143454-43504d7ad19a
 	k8s.io/api v0.29.13
 	k8s.io/apimachinery v0.29.13
@@ -17,7 +18,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.0 // indirect
-	github.com/evanphx/json-patch v5.7.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -72,6 +72,8 @@ github.com/onsi/ginkgo/v2 v2.20.1 h1:YlVIbqct+ZmnEph770q9Q7NVAz4wwIiVNahee6JyUzo
 github.com/onsi/ginkgo/v2 v2.20.1/go.mod h1:lG9ey2Z29hR41WMVthyJBGUBcBhGOtoPF2VFMvBXFCI=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
+github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250204091142-ae8379c31edb h1:SedlzLahRyzctVTXzVrpmjui78A7Z0g8V1cmPBoQzYY=
+github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250204091142-ae8379c31edb/go.mod h1:TDaE7BVQvJwJGFm33R6xcPTeF8LKAnMh+a1ho+YqJHs=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.5.1-0.20250205143454-43504d7ad19a h1:3LuUgB85VxGD6lmVOeZelYEASmytkrzaudU014PN7xw=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.5.1-0.20250205143454-43504d7ad19a/go.mod h1:KxnNSUk15llkKTSq/bQEE7pnc0IMk44fxhoBRpimMa8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/api/v1beta1/barbican_types.go
+++ b/api/v1beta1/barbican_types.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/topology"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -111,6 +112,11 @@ type BarbicanSpecBase struct {
 	// +kubebuilder:default=90
 	// Barbican API timeout
 	APITimeout int `json:"apiTimeout"`
+
+	// +kubebuilder:validation:Optional
+	// TopologyRef to apply the Topology defined by the associated CR referenced
+	// by name
+	TopologyRef *topology.TopoRef `json:"topologyRef,omitempty"`
 }
 
 // BarbicanStatus defines the observed state of Barbican

--- a/api/v1beta1/barbicanapi_types.go
+++ b/api/v1beta1/barbicanapi_types.go
@@ -96,6 +96,9 @@ type BarbicanAPIStatus struct {
 
 	// Barbican Database Hostname
 	DatabaseHostname string `json:"databaseHostname,omitempty"`
+
+	// LastAppliedTopology - the last applied Topology
+	LastAppliedTopology string `json:"lastAppliedTopology,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/barbicankeystonelistener_types.go
+++ b/api/v1beta1/barbicankeystonelistener_types.go
@@ -73,6 +73,9 @@ type BarbicanKeystoneListenerStatus struct {
 
 	// Barbican Database Hostname
 	DatabaseHostname string `json:"databaseHostname,omitempty"`
+
+	// LastAppliedTopology - the last applied Topology
+	LastAppliedTopology string `json:"lastAppliedTopology,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/barbicanworker_types.go
+++ b/api/v1beta1/barbicanworker_types.go
@@ -76,6 +76,9 @@ type BarbicanWorkerStatus struct {
 
 	// Barbican Database Hostname
 	DatabaseHostname string `json:"databaseHostname,omitempty"`
+
+	// LastAppliedTopology - the last applied Topology
+	LastAppliedTopology string `json:"lastAppliedTopology,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -2,6 +2,7 @@ package v1beta1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/topology"
 )
 
 // BarbicanTemplate defines common Spec elements for all Barbican components
@@ -50,18 +51,18 @@ type BarbicanTemplate struct {
 	// ServiceAccount - service account name used internally to provide Barbican services the default SA name
 	ServiceAccount string `json:"serviceAccount"`
 
-        // +kubebuilder:validation:Optional
-        PKCS11 *BarbicanPKCS11Template `json:"pkcs11,omitempty"`
+	// +kubebuilder:validation:Optional
+	PKCS11 *BarbicanPKCS11Template `json:"pkcs11,omitempty"`
 
-        // +kubebuilder:validation:Optional
-        // +kubebuilder:validation:MinItems=1
-        // +kubebuilder:validation:MaxItems=2
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:MaxItems=2
 	// +listType:=set
-        EnabledSecretStores []SecretStore `json:"enabledSecretStores,omitempty"`
+	EnabledSecretStores []SecretStore `json:"enabledSecretStores,omitempty"`
 
-        // +kubebuilder:validation:Optional
-        // +kubebuilder:default="simple_crypto"
-        GlobalDefaultSecretStore SecretStore `json:"globalDefaultSecretStore" yaml:"globalDefaultSecretStore"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="simple_crypto"
+	GlobalDefaultSecretStore SecretStore `json:"globalDefaultSecretStore" yaml:"globalDefaultSecretStore"`
 }
 
 // BarbicanComponentTemplate - Variables used by every sub-component of Barbican
@@ -106,6 +107,11 @@ type BarbicanComponentTemplate struct {
 	// +kubebuilder:validation:Optional
 	// NetworkAttachments is a list of NetworkAttachment resource names to expose the services to the given network
 	NetworkAttachments []string `json:"networkAttachments,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// TopologyRef to apply the Topology defined by the associated CR referenced
+	// by name
+	TopologyRef *topology.TopoRef `json:"topologyRef,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=simple_crypto;pkcs11

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1beta1
 import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/topology"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -273,6 +274,11 @@ func (in *BarbicanComponentTemplate) DeepCopyInto(out *BarbicanComponentTemplate
 		in, out := &in.NetworkAttachments, &out.NetworkAttachments
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.TopologyRef != nil {
+		in, out := &in.TopologyRef, &out.TopologyRef
+		*out = new(topology.TopoRef)
+		**out = **in
 	}
 }
 
@@ -542,6 +548,11 @@ func (in *BarbicanSpecBase) DeepCopyInto(out *BarbicanSpecBase) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.TopologyRef != nil {
+		in, out := &in.TopologyRef, &out.TopologyRef
+		*out = new(topology.TopoRef)
+		**out = **in
 	}
 }
 

--- a/config/crd/bases/barbican.openstack.org_barbicanapis.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicanapis.yaml
@@ -446,6 +446,23 @@ spec:
                       bundle file
                     type: string
                 type: object
+              topologyRef:
+                description: |-
+                  TopologyRef to apply the Topology defined by the associated CR referenced
+                  by name
+                properties:
+                  name:
+                    description: Name - The Topology CR name that the Service references
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace - The Namespace to fetch the Topology CR referenced
+                      NOTE: Namespace currently points by default to the same namespace where
+                      the Service is deployed. Customizing the namespace is not supported and
+                      webhooks prevent editing this field to a value different from the
+                      current project
+                    type: string
+                type: object
               transportURLSecret:
                 description: TransportURLSecret - Secret containing RabbitMQ transportURL
                 type: string
@@ -514,6 +531,9 @@ spec:
                   type: string
                 description: Map of hashes to track e.g. job status
                 type: object
+              lastAppliedTopology:
+                description: LastAppliedTopology - the last applied Topology
+                type: string
               networkAttachments:
                 additionalProperties:
                   items:

--- a/config/crd/bases/barbican.openstack.org_barbicankeystonelisteners.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicankeystonelisteners.yaml
@@ -258,6 +258,23 @@ spec:
                       bundle file
                     type: string
                 type: object
+              topologyRef:
+                description: |-
+                  TopologyRef to apply the Topology defined by the associated CR referenced
+                  by name
+                properties:
+                  name:
+                    description: Name - The Topology CR name that the Service references
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace - The Namespace to fetch the Topology CR referenced
+                      NOTE: Namespace currently points by default to the same namespace where
+                      the Service is deployed. Customizing the namespace is not supported and
+                      webhooks prevent editing this field to a value different from the
+                      current project
+                    type: string
+                type: object
               transportURLSecret:
                 type: string
             required:
@@ -321,6 +338,9 @@ spec:
                   type: string
                 description: Map of hashes to track e.g. job status
                 type: object
+              lastAppliedTopology:
+                description: LastAppliedTopology - the last applied Topology
+                type: string
               networkAttachments:
                 additionalProperties:
                   items:

--- a/config/crd/bases/barbican.openstack.org_barbicans.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicans.yaml
@@ -356,6 +356,24 @@ spec:
                           a pre-created bundle file
                         type: string
                     type: object
+                  topologyRef:
+                    description: |-
+                      TopologyRef to apply the Topology defined by the associated CR referenced
+                      by name
+                    properties:
+                      name:
+                        description: Name - The Topology CR name that the Service
+                          references
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace - The Namespace to fetch the Topology CR referenced
+                          NOTE: Namespace currently points by default to the same namespace where
+                          the Service is deployed. Customizing the namespace is not supported and
+                          webhooks prevent editing this field to a value different from the
+                          current project
+                        type: string
+                    type: object
                 required:
                 - containerImage
                 type: object
@@ -466,6 +484,24 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  topologyRef:
+                    description: |-
+                      TopologyRef to apply the Topology defined by the associated CR referenced
+                      by name
+                    properties:
+                      name:
+                        description: Name - The Topology CR name that the Service
+                          references
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace - The Namespace to fetch the Topology CR referenced
+                          NOTE: Namespace currently points by default to the same namespace where
+                          the Service is deployed. Customizing the namespace is not supported and
+                          webhooks prevent editing this field to a value different from the
+                          current project
+                        type: string
+                    type: object
                 required:
                 - containerImage
                 type: object
@@ -575,6 +611,24 @@ spec:
                           otherwise to an implementation-defined value. Requests cannot exceed Limits.
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
+                    type: object
+                  topologyRef:
+                    description: |-
+                      TopologyRef to apply the Topology defined by the associated CR referenced
+                      by name
+                    properties:
+                      name:
+                        description: Name - The Topology CR name that the Service
+                          references
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace - The Namespace to fetch the Topology CR referenced
+                          NOTE: Namespace currently points by default to the same namespace where
+                          the Service is deployed. Customizing the namespace is not supported and
+                          webhooks prevent editing this field to a value different from the
+                          current project
+                        type: string
                     type: object
                 required:
                 - containerImage
@@ -700,6 +754,23 @@ spec:
                 description: Secret containing the Key Encryption Key (KEK) used for
                   the Simple Crypto backend
                 type: string
+              topologyRef:
+                description: |-
+                  TopologyRef to apply the Topology defined by the associated CR referenced
+                  by name
+                properties:
+                  name:
+                    description: Name - The Topology CR name that the Service references
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace - The Namespace to fetch the Topology CR referenced
+                      NOTE: Namespace currently points by default to the same namespace where
+                      the Service is deployed. Customizing the namespace is not supported and
+                      webhooks prevent editing this field to a value different from the
+                      current project
+                    type: string
+                type: object
             required:
             - barbicanAPI
             - barbicanKeystoneListener

--- a/config/crd/bases/barbican.openstack.org_barbicanworkers.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicanworkers.yaml
@@ -256,6 +256,23 @@ spec:
                       bundle file
                     type: string
                 type: object
+              topologyRef:
+                description: |-
+                  TopologyRef to apply the Topology defined by the associated CR referenced
+                  by name
+                properties:
+                  name:
+                    description: Name - The Topology CR name that the Service references
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace - The Namespace to fetch the Topology CR referenced
+                      NOTE: Namespace currently points by default to the same namespace where
+                      the Service is deployed. Customizing the namespace is not supported and
+                      webhooks prevent editing this field to a value different from the
+                      current project
+                    type: string
+                type: object
               transportURLSecret:
                 type: string
             required:
@@ -318,6 +335,9 @@ spec:
                   type: string
                 description: Map of hashes to track e.g. job status
                 type: object
+              lastAppliedTopology:
+                description: LastAppliedTopology - the last applied Topology
+                type: string
               networkAttachments:
                 additionalProperties:
                   items:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -307,3 +307,12 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
+- apiGroups:
+  - topology.openstack.org
+  resources:
+  - topologies
+  verbs:
+  - get
+  - list
+  - update
+  - watch

--- a/controllers/barbican_common.go
+++ b/controllers/barbican_common.go
@@ -23,9 +23,13 @@ import (
 	"strings"
 
 	barbicanv1beta1 "github.com/openstack-k8s-operators/barbican-operator/api/v1beta1"
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/labels"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/secret"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/topology"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -91,4 +95,65 @@ func GenerateSecretStoreTemplateMap(
 		"PKCS11CryptoEnabled":      slices.Contains(stores, "pkcs11"),
 	}
 	return tempMap, nil
+}
+
+// ensureBarbicanTopology - when a Topology CR is referenced, remove the
+// finalizer from a previous referenced Topology (if any), and retrieve the
+// newly referenced topology object
+func ensureBarbicanTopology(
+	ctx context.Context,
+	helper *helper.Helper,
+	tpRef *topology.TopoRef,
+	lastAppliedTopology *topology.TopoRef,
+	finalizer string,
+	selector string,
+) (*topologyv1.Topology, error) {
+
+	var podTopology *topologyv1.Topology
+	var err error
+
+	// Remove (if present) the finalizer from a previously referenced topology
+	//
+	// 1. a topology reference is removed (tpRef == nil) from the Barbican Component
+	//    subCR and the finalizer should be deleted from the last applied topology
+	//    (lastAppliedTopology != "")
+	// 2. a topology reference is updated in the Barbican Component CR (tpRef != nil)
+	//    and the finalizer should be removed from the previously
+	//    referenced topology (tpRef.Name != lastAppliedTopology.Name)
+	if (tpRef == nil && lastAppliedTopology.Name != "") ||
+		(tpRef != nil && tpRef.Name != lastAppliedTopology.Name) {
+		_, err = topology.EnsureDeletedTopologyRef(
+			ctx,
+			helper,
+			lastAppliedTopology,
+			finalizer,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// TopologyRef is passed as input, get the Topology object
+	if tpRef != nil {
+		// no Namespace is provided, default to instance.Namespace
+		if tpRef.Namespace == "" {
+			tpRef.Namespace = helper.GetBeforeObject().GetNamespace()
+		}
+		// Build a defaultLabelSelector (component=barbican-[api|keystonelistener|worker])
+		defaultLabelSelector := labels.GetSingleLabelSelector(
+			common.ComponentSelector,
+			selector,
+		)
+		// Retrieve the referenced Topology
+		podTopology, _, err = topology.EnsureTopologyRef(
+			ctx,
+			helper,
+			tpRef,
+			finalizer,
+			&defaultLabelSelector,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return podTopology, nil
 }

--- a/controllers/barbican_controller.go
+++ b/controllers/barbican_controller.go
@@ -543,6 +543,7 @@ const (
 	tlsAPIPublicField           = ".spec.tls.api.public.secretName"
 	pkcs11LoginSecretField      = ".spec.pkcs11.loginSecret"
 	pkcs11ClientDataSecretField = ".spec.pkcs11.clientDataSecret"
+	topologyField               = ".spec.topologyRef.Name"
 )
 
 var (
@@ -551,6 +552,7 @@ var (
 		caBundleSecretNameField,
 		pkcs11LoginSecretField,
 		pkcs11ClientDataSecretField,
+		topologyField,
 	}
 	apinWatchFields = []string{
 		passwordSecretField,
@@ -559,10 +561,12 @@ var (
 		tlsAPIPublicField,
 		pkcs11LoginSecretField,
 		pkcs11ClientDataSecretField,
+		topologyField,
 	}
 	listenerWatchFields = []string{
 		passwordSecretField,
 		caBundleSecretNameField,
+		topologyField,
 	}
 )
 
@@ -719,6 +723,12 @@ func (r *BarbicanReconciler) apiDeploymentCreateOrUpdate(ctx context.Context, in
 		apiSpec.NodeSelector = instance.Spec.NodeSelector
 	}
 
+	// If topology is not present in the underlying BarbicanAPITemplate,
+	// inherit from the top-level CR
+	if apiSpec.TopologyRef == nil {
+		apiSpec.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	// Note: The top-level .spec.apiTimeout ALWAYS overrides .spec.barbicanAPI.apiTimeout
 	apiSpec.BarbicanAPITemplate.APITimeout = instance.Spec.APITimeout
 
@@ -766,6 +776,12 @@ func (r *BarbicanReconciler) workerDeploymentCreateOrUpdate(ctx context.Context,
 		workerSpec.NodeSelector = instance.Spec.NodeSelector
 	}
 
+	// If topology is not present in the underlying BarbicanWorkerTemplate,
+	// inherit from the top-level CR
+	if workerSpec.TopologyRef == nil {
+		workerSpec.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	deployment := &barbicanv1beta1.BarbicanWorker{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-worker", instance.Name),
@@ -807,6 +823,12 @@ func (r *BarbicanReconciler) keystoneListenerDeploymentCreateOrUpdate(ctx contex
 	// KeystoneListener instance inherits the value from the top-level CR.
 	if keystoneListenerSpec.NodeSelector == nil {
 		keystoneListenerSpec.NodeSelector = instance.Spec.NodeSelector
+	}
+
+	// If topology is not present in the underlying BarbicanKeystoneListenerTemplate,
+	// inherit from the top-level CR
+	if keystoneListenerSpec.TopologyRef == nil {
+		keystoneListenerSpec.TopologyRef = instance.Spec.TopologyRef
 	}
 
 	deployment := &barbicanv1beta1.BarbicanKeystoneListener{

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ import (
 
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	//+kubebuilder:scaffold:imports
@@ -61,6 +62,7 @@ func init() {
 	utilruntime.Must(keystonev1.AddToScheme(scheme))
 	utilruntime.Must(rabbitmqv1.AddToScheme(scheme))
 	utilruntime.Must(networkv1.AddToScheme(scheme))
+	utilruntime.Must(topologyv1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/pkg/barbican/funcs.go
+++ b/pkg/barbican/funcs.go
@@ -1,6 +1,9 @@
 package barbican
 
 import (
+	common "github.com/openstack-k8s-operators/lib-common/modules/common"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/affinity"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -14,4 +17,18 @@ func GetOwningBarbicanName(instance client.Object) string {
 	}
 
 	return ""
+}
+
+// GetPodAffinity - Returns a corev1.Affinity reference for the specified component.
+func GetPodAffinity(componentName string) *corev1.Affinity {
+	// If possible two pods of the same component (e.g barbican-worker) should not
+	// run on the same worker node. If this is not possible they get still
+	// created on the same worker node.
+	return affinity.DistributePods(
+		common.ComponentSelector,
+		[]string{
+			componentName,
+		},
+		corev1.LabelHostname,
+	)
 }

--- a/pkg/barbicankeystonelistener/deployment.go
+++ b/pkg/barbicankeystonelistener/deployment.go
@@ -10,6 +10,7 @@ import (
 
 	barbicanv1beta1 "github.com/openstack-k8s-operators/barbican-operator/api/v1beta1"
 	barbican "github.com/openstack-k8s-operators/barbican-operator/pkg/barbican"
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 )
 
 const (
@@ -23,6 +24,7 @@ func Deployment(
 	configHash string,
 	labels map[string]string,
 	annotations map[string]string,
+	topology *topologyv1.Topology,
 ) *appsv1.Deployment {
 	runAsUser := int64(0)
 	var config0644AccessMode int32 = 0644
@@ -124,6 +126,24 @@ func Deployment(
 
 	if instance.Spec.NodeSelector != nil {
 		deployment.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
+	}
+
+	if topology != nil {
+		// Get the Topology .Spec
+		ts := topology.Spec
+		// Process TopologySpreadConstraints if defined in the referenced Topology
+		if ts.TopologySpreadConstraints != nil {
+			deployment.Spec.Template.Spec.TopologySpreadConstraints = *topology.Spec.TopologySpreadConstraints
+		}
+		// Process Affinity if defined in the referenced Topology
+		if ts.Affinity != nil {
+			deployment.Spec.Template.Spec.Affinity = ts.Affinity
+		}
+	} else {
+		// If possible two pods of the same service should not
+		// run on the same worker node. If this is not possible
+		// the get still created on the same worker node.
+		deployment.Spec.Template.Spec.Affinity = barbican.GetPodAffinity(barbican.ComponentKeystoneListener)
 	}
 
 	return deployment

--- a/pkg/barbicanworker/deployment.go
+++ b/pkg/barbicanworker/deployment.go
@@ -13,6 +13,7 @@ import (
 
 	barbicanv1beta1 "github.com/openstack-k8s-operators/barbican-operator/api/v1beta1"
 	barbican "github.com/openstack-k8s-operators/barbican-operator/pkg/barbican"
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 )
 
 const (
@@ -26,6 +27,7 @@ func Deployment(
 	configHash string,
 	labels map[string]string,
 	annotations map[string]string,
+	topology *topologyv1.Topology,
 ) *appsv1.Deployment {
 	runAsUser := int64(0)
 	var config0644AccessMode int32 = 0644
@@ -159,6 +161,24 @@ func Deployment(
 
 	if instance.Spec.NodeSelector != nil {
 		deployment.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
+	}
+
+	if topology != nil {
+		// Get the Topology .Spec
+		ts := topology.Spec
+		// Process TopologySpreadConstraints if defined in the referenced Topology
+		if ts.TopologySpreadConstraints != nil {
+			deployment.Spec.Template.Spec.TopologySpreadConstraints = *topology.Spec.TopologySpreadConstraints
+		}
+		// Process Affinity if defined in the referenced Topology
+		if ts.Affinity != nil {
+			deployment.Spec.Template.Spec.Affinity = ts.Affinity
+		}
+	} else {
+		// If possible two pods of the same service should not
+		// run on the same worker node. If this is not possible
+		// the get still created on the same worker node.
+		deployment.Spec.Template.Spec.Affinity = barbican.GetPodAffinity(barbican.ComponentWorker)
 	}
 
 	return deployment

--- a/tests/functional/barbican_test_data.go
+++ b/tests/functional/barbican_test_data.go
@@ -42,39 +42,45 @@ const (
 
 // BarbicanTestData is the data structure used to provide input data to envTest
 type BarbicanTestData struct {
-	BarbicanPassword               string
-	BarbicanServiceUser            string
-	ContainerImage                 string
-	DatabaseHostname               string
-	DatabaseInstance               string
-	RabbitmqClusterName            string
-	RabbitmqSecretName             string
-	Instance                       types.NamespacedName
-	Barbican                       types.NamespacedName
-	BarbicanDatabaseName           types.NamespacedName
-	BarbicanDatabaseAccount        types.NamespacedName
-	BarbicanDBSync                 types.NamespacedName
-	BarbicanPKCS11Prep             types.NamespacedName
-	BarbicanAPI                    types.NamespacedName
-	BarbicanRole                   types.NamespacedName
-	BarbicanRoleBinding            types.NamespacedName
-	BarbicanTransportURL           types.NamespacedName
-	BarbicanSA                     types.NamespacedName
-	BarbicanKeystoneService        types.NamespacedName
-	BarbicanKeystoneEndpoint       types.NamespacedName
-	BarbicanServicePublic          types.NamespacedName
-	BarbicanServiceInternal        types.NamespacedName
-	BarbicanConfigSecret           types.NamespacedName
-	BarbicanAPIConfigSecret        types.NamespacedName
-	BarbicanPKCS11LoginSecret      types.NamespacedName
-	BarbicanPKCS11ClientDataSecret types.NamespacedName
-	BarbicanConfigScripts          types.NamespacedName
-	BarbicanConfigMapData          types.NamespacedName
-	BarbicanScheduler              types.NamespacedName
-	InternalAPINAD                 types.NamespacedName
-	CABundleSecret                 types.NamespacedName
-	InternalCertSecret             types.NamespacedName
-	PublicCertSecret               types.NamespacedName
+	BarbicanPassword                   string
+	BarbicanServiceUser                string
+	ContainerImage                     string
+	DatabaseHostname                   string
+	DatabaseInstance                   string
+	RabbitmqClusterName                string
+	RabbitmqSecretName                 string
+	Instance                           types.NamespacedName
+	Barbican                           types.NamespacedName
+	BarbicanDatabaseName               types.NamespacedName
+	BarbicanDatabaseAccount            types.NamespacedName
+	BarbicanDBSync                     types.NamespacedName
+	BarbicanPKCS11Prep                 types.NamespacedName
+	BarbicanAPI                        types.NamespacedName
+	BarbicanWorker                     types.NamespacedName
+	BarbicanWorkerDeployment           types.NamespacedName
+	BarbicanKeystoneListener           types.NamespacedName
+	BarbicanKeystoneListenerDeployment types.NamespacedName
+	BarbicanAPIDeployment              types.NamespacedName
+	BarbicanRole                       types.NamespacedName
+	BarbicanRoleBinding                types.NamespacedName
+	BarbicanTransportURL               types.NamespacedName
+	BarbicanSA                         types.NamespacedName
+	BarbicanKeystoneService            types.NamespacedName
+	BarbicanKeystoneEndpoint           types.NamespacedName
+	BarbicanServicePublic              types.NamespacedName
+	BarbicanServiceInternal            types.NamespacedName
+	BarbicanConfigSecret               types.NamespacedName
+	BarbicanAPIConfigSecret            types.NamespacedName
+	BarbicanPKCS11LoginSecret          types.NamespacedName
+	BarbicanPKCS11ClientDataSecret     types.NamespacedName
+	BarbicanConfigScripts              types.NamespacedName
+	BarbicanConfigMapData              types.NamespacedName
+	BarbicanScheduler                  types.NamespacedName
+	InternalAPINAD                     types.NamespacedName
+	CABundleSecret                     types.NamespacedName
+	InternalCertSecret                 types.NamespacedName
+	PublicCertSecret                   types.NamespacedName
+	BarbicanTopologies                 []types.NamespacedName
 }
 
 // GetBarbicanTestData is a function that initialize the BarbicanTestData
@@ -104,9 +110,29 @@ func GetBarbicanTestData(barbicanName types.NamespacedName) BarbicanTestData {
 			Namespace: barbicanName.Namespace,
 			Name:      fmt.Sprintf("%s-pkcs11-prep", barbicanName.Name),
 		},
-		BarbicanAPI: types.NamespacedName{
+		BarbicanAPIDeployment: types.NamespacedName{
 			Namespace: barbicanName.Namespace,
 			Name:      fmt.Sprintf("%s-api-api", barbicanName.Name),
+		},
+		BarbicanAPI: types.NamespacedName{
+			Namespace: barbicanName.Namespace,
+			Name:      fmt.Sprintf("%s-api", barbicanName.Name),
+		},
+		BarbicanKeystoneListener: types.NamespacedName{
+			Namespace: barbicanName.Namespace,
+			Name:      fmt.Sprintf("%s-keystone-listener", barbicanName.Name),
+		},
+		BarbicanKeystoneListenerDeployment: types.NamespacedName{
+			Namespace: barbicanName.Namespace,
+			Name:      fmt.Sprintf("%s-keystone-listener-keystone-listener", barbicanName.Name),
+		},
+		BarbicanWorker: types.NamespacedName{
+			Namespace: barbicanName.Namespace,
+			Name:      fmt.Sprintf("%s-worker", barbicanName.Name),
+		},
+		BarbicanWorkerDeployment: types.NamespacedName{
+			Namespace: barbicanName.Namespace,
+			Name:      fmt.Sprintf("%s-worker-worker", barbicanName.Name),
 		},
 		BarbicanRole: types.NamespacedName{
 			Namespace: barbicanName.Namespace,
@@ -193,5 +219,26 @@ func GetBarbicanTestData(barbicanName types.NamespacedName) BarbicanTestData {
 		BarbicanServiceUser: "barbican",
 		ContainerImage:      "test://barbican",
 		DatabaseHostname:    "database-hostname",
+		// A set of topologies to Test how the reference is propagated to the
+		// resulting StatefulSets and if a potential override produces the
+		// expected values
+		BarbicanTopologies: []types.NamespacedName{
+			{
+				Namespace: barbicanName.Namespace,
+				Name:      fmt.Sprintf("%s-global-topology", barbicanName.Name),
+			},
+			{
+				Namespace: barbicanName.Namespace,
+				Name:      fmt.Sprintf("%s-api-topology", barbicanName.Name),
+			},
+			{
+				Namespace: barbicanName.Namespace,
+				Name:      fmt.Sprintf("%s-klistener-topology", barbicanName.Name),
+			},
+			{
+				Namespace: barbicanName.Namespace,
+				Name:      fmt.Sprintf("%s-worker-topology", barbicanName.Name),
+			},
+		},
 	}
 }

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -134,8 +134,27 @@ func BarbicanAPIExists(name types.NamespacedName) {
 	}, timeout, interval).Should(Succeed())
 }
 
+// GetBarbicanAPI - Returns BarbicanAPI subCR
 func GetBarbicanAPI(name types.NamespacedName) *barbicanv1.BarbicanAPI {
 	instance := &barbicanv1.BarbicanAPI{}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, name, instance)).Should(Succeed())
+	}, timeout, interval).Should(Succeed())
+	return instance
+}
+
+// GetBarbicanKeystoneListener - Returns BarbicanKeystoneListener subCR
+func GetBarbicanKeystoneListener(name types.NamespacedName) *barbicanv1.BarbicanKeystoneListener {
+	instance := &barbicanv1.BarbicanKeystoneListener{}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, name, instance)).Should(Succeed())
+	}, timeout, interval).Should(Succeed())
+	return instance
+}
+
+// GetBarbicanWorker - Returns BarbicanWorker subCR
+func GetBarbicanWorker(name types.NamespacedName) *barbicanv1.BarbicanWorker {
+	instance := &barbicanv1.BarbicanWorker{}
 	Eventually(func(g Gomega) {
 		g.Expect(k8sClient.Get(ctx, name, instance)).Should(Succeed())
 	}, timeout, interval).Should(Succeed())
@@ -264,4 +283,66 @@ func CreateBarbicanAPI(name types.NamespacedName, spec map[string]interface{}) c
 	}
 
 	return th.CreateUnstructured(raw)
+}
+
+// GetSampleTopologySpec - A sample (and opinionated) Topology Spec used to
+// test Service components
+func GetSampleTopologySpec() map[string]interface{} {
+	// Build the topology Spec
+	topologySpec := map[string]interface{}{
+		"topologySpreadConstraints": []map[string]interface{}{
+			{
+				"maxSkew":           1,
+				"topologyKey":       corev1.LabelHostname,
+				"whenUnsatisfiable": "ScheduleAnyway",
+				"labelSelector": map[string]interface{}{
+					"matchLabels": map[string]interface{}{
+						"service": barbicanName.Name,
+					},
+				},
+			},
+		},
+	}
+	return topologySpec
+}
+
+// CreateTopology - Creates a Topology CR based on the spec passed as input
+func CreateTopology(topology types.NamespacedName, spec map[string]interface{}) client.Object {
+	raw := map[string]interface{}{
+		"apiVersion": "topology.openstack.org/v1beta1",
+		"kind":       "Topology",
+		"metadata": map[string]interface{}{
+			"name":      topology.Name,
+			"namespace": topology.Namespace,
+		},
+		"spec": spec,
+	}
+	return th.CreateUnstructured(raw)
+}
+
+// GetBarbicanAPISpec -
+func GetBarbicanAPISpec(name types.NamespacedName) barbicanv1.BarbicanAPITemplate {
+	instance := &barbicanv1.BarbicanAPI{}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, name, instance)).Should(Succeed())
+	}, timeout, interval).Should(Succeed())
+	return instance.Spec.BarbicanAPITemplate
+}
+
+// GetBarbicanKeystoneListenerSpec -
+func GetBarbicanKeystoneListenerSpec(name types.NamespacedName) barbicanv1.BarbicanKeystoneListenerTemplate {
+	instance := &barbicanv1.BarbicanKeystoneListener{}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, name, instance)).Should(Succeed())
+	}, timeout, interval).Should(Succeed())
+	return instance.Spec.BarbicanKeystoneListenerTemplate
+}
+
+// GetBarbicanWorkerSpec -
+func GetBarbicanWorkerSpec(name types.NamespacedName) barbicanv1.BarbicanWorkerTemplate {
+	instance := &barbicanv1.BarbicanWorker{}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, name, instance)).Should(Succeed())
+	}, timeout, interval).Should(Succeed())
+	return instance.Spec.BarbicanWorkerTemplate
 }


### PR DESCRIPTION
This patch provides more granular control over `Pod` placement and scheduling through the `Topology` CR integration introduced in `infra-operator`.

In particular it provides:

- a new `API` parameter (`TopologyRef`) defined for each `Component` that allows to reference an existing `Topology CRs` in the same namespace

- the operator logic that retrieves and processes the referenced `Topology CR` through the functions provided by lib-common

- enhanced `Deployment` configuration that incorporates the processed `Topology`

- a set of `envTest` to test the lifecycle (add/update/override/remove) of the resulting `Deployment` when a `Topology` is referenced

Note that webhooks are in place to prevent referencing a Topology from a different namespace (which is not a supported scenario).