### PR TITLE
Set APITimeout minimum validation

### DIFF
--- a/api/bases/barbican.openstack.org_barbicans.yaml
+++ b/api/bases/barbican.openstack.org_barbicans.yaml
@@ -51,6 +51,7 @@ spec:
               apiTimeout:
                 default: 90
                 description: Barbican API timeout
+                minimum: 10
                 type: integer
               barbicanAPI:
                 description: BarbicanAPI - Spec definition for the  API services of

--- a/api/v1beta1/barbican_types.go
+++ b/api/v1beta1/barbican_types.go
@@ -112,6 +112,7 @@ type BarbicanSpecBase struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=90
+	// +kubebuilder:validation:Minimum=10
 	// Barbican API timeout
 	APITimeout int `json:"apiTimeout"`
 }

--- a/config/crd/bases/barbican.openstack.org_barbicans.yaml
+++ b/config/crd/bases/barbican.openstack.org_barbicans.yaml
@@ -51,6 +51,7 @@ spec:
               apiTimeout:
                 default: 90
                 description: Barbican API timeout
+                minimum: 10
                 type: integer
               barbicanAPI:
                 description: BarbicanAPI - Spec definition for the  API services of


### PR DESCRIPTION
 ...to prevent user from setting a negative value. Minimum value of 10 follows common implementation in other operators.