### PR TITLE
Gracefully clean up old deployments with duplicate names

### DIFF
--- a/controllers/barbican_controller.go
+++ b/controllers/barbican_controller.go
@@ -50,6 +50,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	"golang.org/x/exp/maps"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -1151,4 +1152,27 @@ func (r *BarbicanReconciler) ensureDB(
 	instance.Status.DatabaseHostname = db.GetDatabaseHostname()
 	instance.Status.Conditions.MarkTrue(condition.DBReadyCondition, condition.DBReadyMessage)
 	return db, ctrlResult, nil
+}
+
+func cleanupOldDeployment(ctx context.Context, c client.Client, namespace string, oldName string) error {
+	var oldDeployment appsv1.Deployment
+	err := c.Get(ctx, types.NamespacedName{Name: oldName, Namespace: namespace}, &oldDeployment)
+	if err != nil {
+		return client.IgnoreNotFound(err)
+	}
+
+	if oldDeployment.Spec.Replicas == nil || *oldDeployment.Spec.Replicas > 0 {
+		replicas := int32(0)
+		oldDeployment.Spec.Replicas = &replicas
+		if updateErr := c.Update(ctx, &oldDeployment); updateErr != nil {
+			return fmt.Errorf("failed to scale down old deployment '%s': %w", oldName, updateErr)
+		}
+		return nil
+	}
+
+	if delErr := c.Delete(ctx, &oldDeployment); delErr != nil {
+		return fmt.Errorf("failed to delete old deployment '%s': %w", oldName, delErr)
+	}
+
+	return nil
 }

--- a/controllers/barbicanapi_controller.go
+++ b/controllers/barbicanapi_controller.go
@@ -924,6 +924,15 @@ func (r *BarbicanAPIReconciler) reconcileNormal(ctx context.Context, instance *b
 	}
 	// create Deployment - end
 
+	if depl.GetDeployment().Status.ReadyReplicas > 0 {
+		oldDepName := fmt.Sprintf("%s-api", instance.Name)
+		err := cleanupOldDeployment(ctx, r.Client, instance.Namespace, fmt.Sprintf("%s-api", instance.Name))
+		log.FromContext(ctx).Info("Attempting to clean up legacy deployment: " + oldDepName)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
 	Log.Info(fmt.Sprintf("Reconciled Service '%s' in barbicanAPI successfully", instance.Name))
 
 	// We reached the end of the Reconcile, update the Ready condition based on

--- a/controllers/barbicankeystonelistener_controller.go
+++ b/controllers/barbicankeystonelistener_controller.go
@@ -640,6 +640,15 @@ func (r *BarbicanKeystoneListenerReconciler) reconcileNormal(ctx context.Context
 	}
 	// create Deployment - end
 
+	if depl.GetDeployment().Status.ReadyReplicas > 0 {
+		oldDepName := fmt.Sprintf("%s-api", instance.Name)
+		err := cleanupOldDeployment(ctx, r.Client, instance.Namespace, fmt.Sprintf("%s-keystone-listener", instance.Name))
+		log.FromContext(ctx).Info("Attempting to clean up legacy deployment: " + oldDepName)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
 	// We reached the end of the Reconcile, update the Ready condition based on
 	// the sub conditions
 	if instance.Status.Conditions.AllSubConditionIsTrue() {

--- a/controllers/barbicanworker_controller.go
+++ b/controllers/barbicanworker_controller.go
@@ -655,6 +655,15 @@ func (r *BarbicanWorkerReconciler) reconcileNormal(ctx context.Context, instance
 	}
 	// create Deployment - end
 
+	if depl.GetDeployment().Status.ReadyReplicas > 0 {
+		oldDepName := fmt.Sprintf("%s-api", instance.Name)
+		err := cleanupOldDeployment(ctx, r.Client, instance.Namespace, fmt.Sprintf("%s-worker", instance.Name))
+		log.FromContext(ctx).Info("Attempting to clean up legacy deployment: " + oldDepName)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
 	// We reached the end of the Reconcile, update the Ready condition based on
 	// the sub conditions
 	if instance.Status.Conditions.AllSubConditionIsTrue() {


### PR DESCRIPTION
After [#225](https://github.com/openstack-k8s-operators/barbican-operator/pull/225), old Barbican deployments with duplicate name suffixes (e.g., barbican-api-api) are no longer automatically removed.

This patch introduces a cleanup mechanism that attempts to gracefully scale down and delete old deployments once the new deployments are ready.