### PR TITLE
Run Barbican services without root

### DIFF
--- a/pkg/barbican/const.go
+++ b/pkg/barbican/const.go
@@ -65,4 +65,8 @@ const (
 	PKCS11ClientDataVolume = "pkcs11-client-data"
 	// PKCS11DataVolume is the mount point used for PKCS11 client Data
 	PKCS11ClientDataMountPoint = "/var/lib/config-data/hsm"
+	// BarbicanUID
+	BarbicanUID int64 = 42403
+	// BarbicanGID
+	BarbicanGID int64 = 42403
 )

--- a/pkg/barbican/const.go
+++ b/pkg/barbican/const.go
@@ -65,8 +65,8 @@ const (
 	PKCS11ClientDataVolume = "pkcs11-client-data"
 	// PKCS11DataVolume is the mount point used for PKCS11 client Data
 	PKCS11ClientDataMountPoint = "/var/lib/config-data/hsm"
-	// BarbicanUID
+	// BarbicanUID - based on https://github.com/openstack-k8s-operators/tcib/blob/main/container-images/kolla/base/uid_gid_manage.sh
 	BarbicanUID int64 = 42403
-	// BarbicanGID
+	// BarbicanGID - based on https://github.com/openstack-k8s-operators/tcib/blob/main/container-images/kolla/base/uid_gid_manage.sh
 	BarbicanGID int64 = 42403
 )

--- a/pkg/barbican/dbsync.go
+++ b/pkg/barbican/dbsync.go
@@ -17,17 +17,7 @@ const (
 // DbSyncJob func
 func DbSyncJob(instance *barbicanv1beta1.Barbican, labels map[string]string, annotations map[string]string) *batchv1.Job {
 	// The dbsync job just needs the main barbican config files
-	dbSyncVolumes := []corev1.Volume{}
-	dbSyncVolumes = append(dbSyncVolumes, GetVolumes(instance.Name)...)
-
-	dbSyncMounts := []corev1.VolumeMount{
-		{
-			Name:      "db-sync-config-data",
-			MountPath: "/etc/barbican/barbican.conf.d",
-			ReadOnly:  true,
-		},
-	}
-	dbSyncMounts = append(dbSyncMounts, GetVolumeMounts()...)
+	dbSyncVolumes, dbSyncMounts := GetDBSyncVolumes(instance.Name)
 
 	// add CA cert if defined
 	if instance.Spec.BarbicanAPI.TLS.CaBundleSecretName != "" {
@@ -64,9 +54,9 @@ func DbSyncJob(instance *barbicanv1beta1.Barbican, labels map[string]string, ann
 							},
 							Args:            args,
 							Image:           instance.Spec.BarbicanAPI.ContainerImage,
-							SecurityContext: dbSyncSecurityContext(),
+							SecurityContext: GetBaseSecurityContext(),
 							Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts: dbSyncMounts,
+							VolumeMounts:    dbSyncMounts,
 						},
 					},
 				},

--- a/pkg/barbican/funcs.go
+++ b/pkg/barbican/funcs.go
@@ -4,6 +4,7 @@ import (
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/affinity"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -31,4 +32,57 @@ func GetPodAffinity(componentName string) *corev1.Affinity {
 		},
 		corev1.LabelHostname,
 	)
+}
+
+// BaseSecurityContext - currently used to make sure we don't run cronJob and Log
+// Pods as root user, and we drop privileges and Capabilities we don't need
+func BaseSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		RunAsUser:                ptr.To(BarbicanUID),
+		RunAsGroup:               ptr.To(BarbicanGID),
+		RunAsNonRoot:             ptr.To(true),
+		AllowPrivilegeEscalation: ptr.To(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"ALL",
+			},
+		},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}
+
+// HttpdSecurityContext -
+func HttpdSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"MKNOD",
+			},
+		},
+		RunAsUser:  ptr.To(BarbicanUID),
+		RunAsGroup: ptr.To(BarbicanGID),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}
+
+// dbSyncSecurityContext - currently used to make sure we don't run db-sync as
+// root user
+func dbSyncSecurityContext() *corev1.SecurityContext {
+
+	return &corev1.SecurityContext{
+		RunAsUser:  ptr.To(BarbicanUID),
+		RunAsGroup: ptr.To(BarbicanGID),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"MKNOD",
+			},
+		},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
 }

--- a/pkg/barbican/funcs.go
+++ b/pkg/barbican/funcs.go
@@ -34,9 +34,9 @@ func GetPodAffinity(componentName string) *corev1.Affinity {
 	)
 }
 
-// BaseSecurityContext - currently used to make sure we don't run cronJob and Log
-// Pods as root user, and we drop privileges and Capabilities we don't need
-func BaseSecurityContext() *corev1.SecurityContext {
+// GetLogSecurityContext - do not run Log containers as root user and drop
+// all privileges and Capabilities
+func GetLogSecurityContext() *corev1.SecurityContext {
 	return &corev1.SecurityContext{
 		RunAsUser:                ptr.To(BarbicanUID),
 		RunAsGroup:               ptr.To(BarbicanGID),
@@ -47,14 +47,11 @@ func BaseSecurityContext() *corev1.SecurityContext {
 				"ALL",
 			},
 		},
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
 	}
 }
 
-// HttpdSecurityContext -
-func HttpdSecurityContext() *corev1.SecurityContext {
+// GetBaseSecurityContext - security Context for an httpd that runs barbican-api
+func GetBaseSecurityContext() *corev1.SecurityContext {
 	return &corev1.SecurityContext{
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{
@@ -63,26 +60,16 @@ func HttpdSecurityContext() *corev1.SecurityContext {
 		},
 		RunAsUser:  ptr.To(BarbicanUID),
 		RunAsGroup: ptr.To(BarbicanGID),
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
 	}
 }
 
-// dbSyncSecurityContext - currently used to make sure we don't run db-sync as
-// root user
-func dbSyncSecurityContext() *corev1.SecurityContext {
-
+// GetServiceSecurityContext - It defined and returns a securityContext for a
+// barbican service (keystone-listener and worker)
+func GetServiceSecurityContext(privileged bool) *corev1.SecurityContext {
 	return &corev1.SecurityContext{
-		RunAsUser:  ptr.To(BarbicanUID),
-		RunAsGroup: ptr.To(BarbicanGID),
-		Capabilities: &corev1.Capabilities{
-			Drop: []corev1.Capability{
-				"MKNOD",
-			},
-		},
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
+		AllowPrivilegeEscalation: ptr.To(true),
+		RunAsUser:                ptr.To(BarbicanUID),
+		RunAsGroup:               ptr.To(BarbicanGID),
+		Privileged:               &privileged,
 	}
 }

--- a/pkg/barbican/volumes.go
+++ b/pkg/barbican/volumes.go
@@ -145,3 +145,43 @@ func GetCustomConfigVolumeMount() corev1.VolumeMount {
 		ReadOnly:  true,
 	}
 }
+
+// GetDBSyncVolumes - dbsync volumes
+// Unlike the individual Barbican services, the DbSyncJob doesn't need a
+// secret that contains all of the config snippets required by every
+// service, The two snippet files that it does need (DefaultsConfigFileName
+// and CustomConfigFileName) can be extracted from the top-level barbican
+// config-data secret.
+func GetDBSyncVolumes(name string) ([]corev1.Volume, []corev1.VolumeMount) {
+	var config0644AccessMode int32 = 0644
+	dbSyncVolumes := []corev1.Volume{
+		{
+			Name: "db-sync-config-data",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					DefaultMode: &config0644AccessMode,
+					SecretName:  name + "-config-data",
+					Items: []corev1.KeyToPath{
+						{
+							Key:  DefaultsConfigFileName,
+							Path: DefaultsConfigFileName,
+						},
+						{
+							Key:  CustomConfigFileName,
+							Path: CustomConfigFileName,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dbSyncVolumeMount := []corev1.VolumeMount{
+		{
+			Name:      "db-sync-config-data",
+			MountPath: "/etc/barbican/barbican.conf.d",
+			ReadOnly:  true,
+		},
+	}
+	return dbSyncVolumes, dbSyncVolumeMount
+}

--- a/pkg/barbicanapi/deployment.go
+++ b/pkg/barbicanapi/deployment.go
@@ -26,7 +26,7 @@ func Deployment(
 	annotations map[string]string,
 	topology *topologyv1.Topology,
 ) (*appsv1.Deployment, error) {
-	runAsUser := int64(0)
+	var config0644AccessMode int32 = 0644
 	envVars := map[string]env.Setter{}
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
@@ -96,15 +96,13 @@ func Deployment(
 								"-F",
 								barbican.BarbicanLogPath + instance.Name + ".log",
 							},
-							Image: instance.Spec.ContainerImage,
-							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: &runAsUser,
-							},
-							Env:            env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts:   []corev1.VolumeMount{barbican.GetLogVolumeMount()},
-							Resources:      instance.Spec.Resources,
-							ReadinessProbe: readinessProbe,
-							LivenessProbe:  livenessProbe,
+							Image:           instance.Spec.ContainerImage,
+							SecurityContext: barbican.BaseSecurityContext(),
+							Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
+							VolumeMounts:    []corev1.VolumeMount{barbican.GetLogVolumeMount()},
+							Resources:       instance.Spec.Resources,
+							ReadinessProbe:  readinessProbe,
+							LivenessProbe:   livenessProbe,
 						},
 						{
 							Name: barbican.ServiceName + "-api",
@@ -113,9 +111,7 @@ func Deployment(
 							},
 							Args:  args,
 							Image: instance.Spec.ContainerImage,
-							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: &runAsUser,
-							},
+							SecurityContext: barbican.HttpdSecurityContext(),
 							Env:            env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:   apiVolumeMounts,
 							Resources:      instance.Spec.Resources,

--- a/pkg/barbicanapi/deployment.go
+++ b/pkg/barbicanapi/deployment.go
@@ -26,7 +26,6 @@ func Deployment(
 	annotations map[string]string,
 	topology *topologyv1.Topology,
 ) (*appsv1.Deployment, error) {
-	var config0644AccessMode int32 = 0644
 	envVars := map[string]env.Setter{}
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
@@ -97,7 +96,7 @@ func Deployment(
 								barbican.BarbicanLogPath + instance.Name + ".log",
 							},
 							Image:           instance.Spec.ContainerImage,
-							SecurityContext: barbican.BaseSecurityContext(),
+							SecurityContext: barbican.GetBaseSecurityContext(),
 							Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:    []corev1.VolumeMount{barbican.GetLogVolumeMount()},
 							Resources:       instance.Spec.Resources,
@@ -109,14 +108,14 @@ func Deployment(
 							Command: []string{
 								"/bin/bash",
 							},
-							Args:  args,
-							Image: instance.Spec.ContainerImage,
-							SecurityContext: barbican.HttpdSecurityContext(),
-							Env:            env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts:   apiVolumeMounts,
-							Resources:      instance.Spec.Resources,
-							ReadinessProbe: readinessProbe,
-							LivenessProbe:  livenessProbe,
+							Args:            args,
+							Image:           instance.Spec.ContainerImage,
+							SecurityContext: barbican.GetBaseSecurityContext(),
+							Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
+							VolumeMounts:    apiVolumeMounts,
+							Resources:       instance.Spec.Resources,
+							ReadinessProbe:  readinessProbe,
+							LivenessProbe:   livenessProbe,
 						},
 					},
 				},

--- a/pkg/barbicanworker/deployment.go
+++ b/pkg/barbicanworker/deployment.go
@@ -26,7 +26,6 @@ func Deployment(
 	annotations map[string]string,
 	topology *topologyv1.Topology,
 ) *appsv1.Deployment {
-	runAsUser := int64(0)
 	envVars := map[string]env.Setter{}
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
@@ -89,13 +88,11 @@ func Deployment(
 								"-F",
 								barbican.BarbicanLogPath + instance.Name + ".log",
 							},
-							Image: instance.Spec.ContainerImage,
-							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: &runAsUser,
-							},
-							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts: []corev1.VolumeMount{barbican.GetLogVolumeMount()},
-							Resources:    instance.Spec.Resources,
+							Image:           instance.Spec.ContainerImage,
+							SecurityContext: barbican.GetLogSecurityContext(),
+							Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
+							VolumeMounts:    []corev1.VolumeMount{barbican.GetLogVolumeMount()},
+							Resources:       instance.Spec.Resources,
 							//ReadinessProbe: readinessProbe,
 							//LivenessProbe:  livenessProbe,
 						},
@@ -104,14 +101,12 @@ func Deployment(
 							Command: []string{
 								"/bin/bash",
 							},
-							Args:  args,
-							Image: instance.Spec.ContainerImage,
-							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: &runAsUser,
-							},
-							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts: workerVolumeMounts,
-							Resources:    instance.Spec.Resources,
+							Args:            args,
+							Image:           instance.Spec.ContainerImage,
+							SecurityContext: barbican.GetServiceSecurityContext(false),
+							Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
+							VolumeMounts:    workerVolumeMounts,
+							Resources:       instance.Spec.Resources,
 							//ReadinessProbe: readinessProbe,
 							//LivenessProbe:  livenessProbe,
 						},

--- a/templates/barbican/config/barbican-api-config.json
+++ b/templates/barbican/config/barbican-api-config.json
@@ -4,14 +4,14 @@
     {
       "source": "/var/lib/config-data/default/10-barbican_wsgi_main.conf",
       "dest": "/etc/httpd/conf.d/10-barbican_wsgi_main.conf",
-      "owner": "root",
+      "owner": "barbican:apache",
       "perm": "0640",
       "optional": true
     },
     {
       "source": "/var/lib/config-data/default/httpd.conf",
       "dest": "/etc/httpd/conf/httpd.conf",
-      "owner": "root",
+      "owner": "barbican:apache",
       "perm": "0640",
       "optional": true
     },
@@ -25,7 +25,7 @@
     {
       "source": "/var/lib/config-data/default/mime.conf",
       "dest": "/etc/httpd/conf.modules.d/mime.conf",
-      "owner": "root",
+      "owner": "barbican:apache",
       "perm": "0640",
       "optional": true
     },
@@ -39,13 +39,13 @@
     {
       "source": "/var/lib/config-data/default/ssl.conf",
       "dest": "/etc/httpd/conf.d/ssl.conf",
-      "owner": "root",
+      "owner": "barbican",
       "perm": "0644"
     },
     {
       "source": "/var/lib/config-data/tls/certs/*",
       "dest": "/etc/pki/tls/certs/",
-      "owner": "root",
+      "owner": "barbican",
       "perm": "0640",
       "optional": true,
       "merge": true
@@ -53,7 +53,7 @@
     {
       "source": "/var/lib/config-data/tls/private/*",
       "dest": "/etc/pki/tls/private/",
-      "owner": "root",
+      "owner": "barbican",
       "perm": "0600",
       "optional": true,
       "merge": true
@@ -68,6 +68,11 @@
     }
   ],
   "permissions": [
+    {
+        "path": "/etc/httpd/run",
+        "owner": "barbican:apache",
+        "recurse": true
+    },
     {
       "path": "/var/log/barbican",
       "owner": "barbican:barbican",

--- a/tests/kuttl/tests/barbican_tls/01-assert.yaml
+++ b/tests/kuttl/tests/barbican_tls/01-assert.yaml
@@ -87,7 +87,7 @@ spec:
             timeoutSeconds: 5
           resources: {}
           securityContext:
-            runAsUser: 0
+            runAsUser: 42403
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
@@ -111,7 +111,7 @@ spec:
             timeoutSeconds: 5
           resources: {}
           securityContext:
-            runAsUser: 0
+            runAsUser: 42403
           volumeMounts:
             - mountPath: /var/lib/config-data/default
               name: config-data


### PR DESCRIPTION
As done for several service operators, this patch removes root from the `Barbican` services.
`SecurityContexts` are created to address requirements related to different services.

Jira: https://issues.redhat.com/browse/OSPRH-15340