### PR TITLE
[WIP] AppCred service operator support

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -79,3 +79,5 @@ replace github.com/openshift/api => github.com/openshift/api v0.0.0-202408300231
 
 // custom RabbitmqClusterSpecCore for OpenStackControlplane (v2.6.0_patches_tag)
 replace github.com/rabbitmq/cluster-operator/v2 => github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.20241017142550-a3524acedd49 //allow-merging
+
+replace github.com/openstack-k8s-operators/keystone-operator/api => github.com/Deydra71/keystone-operator/api v0.0.0-20250428100042-040976c94314

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,6 +19,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
   verbs:
   - create
@@ -199,6 +207,14 @@ rules:
   - k8s.cni.cncf.io
   resources:
   - network-attachment-definitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - keystone.openstack.org
+  resources:
+  - applicationcredentials
   verbs:
   - get
   - list

--- a/controllers/barbican_controller.go
+++ b/controllers/barbican_controller.go
@@ -94,6 +94,7 @@ func (r *BarbicanReconciler) GetLogger(ctx context.Context) logr.Logger {
 //+kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneapis,verbs=get;list;watch;
 //+kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneservices,verbs=get;list;watch;create;update;patch;delete;
 //+kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneendpoints,verbs=get;list;watch;create;update;patch;delete;
+//+kubebuilder:rbac:groups=keystone.openstack.org,resources=applicationcredentials,verbs=get;list;watch
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete;
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete;
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete;
@@ -108,6 +109,7 @@ func (r *BarbicanReconciler) GetLogger(ctx context.Context) logr.Logger {
 
 // service account, role, rolebinding
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid,resources=securitycontextconstraints,verbs=use
@@ -659,6 +661,25 @@ func (r *BarbicanReconciler) generateServiceConfig(
 		"TransportURL":     string(transportURLSecret.Data["transport_url"]),
 		"LogFile":          fmt.Sprintf("%s%s.log", barbican.BarbicanLogPath, instance.Name),
 		"EnableSecureRBAC": instance.Spec.BarbicanAPI.EnableSecureRBAC,
+	}
+
+	templateParameters["UseApplicationCredentials"] = false
+	// fetch AC CR
+	ac := &keystonev1.ApplicationCredential{}
+	acName := types.NamespacedName{Namespace: instance.Namespace, Name: fmt.Sprintf("ac-%s", barbican.ServiceName)}
+	if err := r.Client.Get(ctx, acName, ac); err == nil {
+		// fetch AC Secret
+		secret := &corev1.Secret{}
+		secName := types.NamespacedName{Namespace: ac.Namespace, Name: ac.Status.SecretName}
+		if err := r.Client.Get(ctx, secName, secret); err == nil {
+			// switch to application credentials auth
+			templateParameters["UseApplicationCredentials"] = true
+			templateParameters["ACID"] = string(secret.Data["AC_ID"])
+			templateParameters["ACSecret"] = string(secret.Data["AC_SECRET"])
+			Log.Info("Using ApplicationCredentials auth")
+		}
+	} else if !k8s_errors.IsNotFound(err) {
+		return err
 	}
 
 	// To avoid a json parsing error in kolla files, we always need to set PKCS11ClientDataPath

--- a/controllers/barbicankeystonelistener_controller.go
+++ b/controllers/barbicankeystonelistener_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openstack-k8s-operators/barbican-operator/pkg/barbican"
 	"github.com/openstack-k8s-operators/barbican-operator/pkg/barbicankeystonelistener"
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
+	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 
 	// keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
@@ -401,6 +402,36 @@ func (r *BarbicanKeystoneListenerReconciler) reconcileNormal(ctx context.Context
 
 	Log.Info(fmt.Sprintf("[KeystoneListener] Got secrets '%s'", instance.Name))
 
+	// check for  ApplicationCredential
+	acName := fmt.Sprintf("ac-%s", barbican.ServiceName)
+	ac := &keystonev1.ApplicationCredential{}
+	err = r.Client.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: acName}, ac)
+	if k8s_errors.IsNotFound(err) {
+		Log.Info("No ApplicationCredential CR found, using password auth", "ac", acName)
+	} else if err != nil {
+		return ctrl.Result{}, err
+	} else {
+		secretName := ac.Status.SecretName
+		if secretName == "" {
+			Log.Info("ApplicationCredential created but Secret not yet ready, requeueing", "ac", acName)
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+		hashAC, res, err := secret.VerifySecret(
+			ctx,
+			types.NamespacedName{Name: secretName, Namespace: instance.Namespace},
+			[]string{"AC_ID", "AC_SECRET"},
+			helper.GetClient(),
+			10*time.Second,
+		)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if res.RequeueAfter > 0 {
+			return res, nil
+		}
+		configVars["secret-"+secretName] = env.SetValue(hashAC)
+	}
+
 	//
 	// TLS input validation
 	//
@@ -695,7 +726,7 @@ func (r *BarbicanKeystoneListenerReconciler) SetupWithManager(mgr ctrl.Manager) 
 		return err
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		For(&barbicanv1beta1.BarbicanKeystoneListener{}).
 		// Owns(&corev1.Service{}).
 		// Owns(&corev1.Secret{}).
@@ -708,8 +739,11 @@ func (r *BarbicanKeystoneListenerReconciler) SetupWithManager(mgr ctrl.Manager) 
 		).
 		Watches(&topologyv1.Topology{},
 			handler.EnqueueRequestsFromMapFunc(r.findObjectsForSrc),
-			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Complete(r)
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		)
+	b = AddACWatches(b)
+	return b.Complete(r)
+
 }
 
 func (r *BarbicanKeystoneListenerReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {

--- a/go.mod
+++ b/go.mod
@@ -92,3 +92,5 @@ replace github.com/openshift/api => github.com/openshift/api v0.0.0-202408300231
 
 // custom RabbitmqClusterSpecCore for OpenStackControlplane (v2.6.0_patches_tag)
 replace github.com/rabbitmq/cluster-operator/v2 => github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.20241017142550-a3524acedd49 //allow-merging
+
+replace github.com/openstack-k8s-operators/keystone-operator/api => github.com/Deydra71/keystone-operator/api v0.0.0-20250428100042-040976c94314

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Deydra71/keystone-operator/api v0.0.0-20250428100042-040976c94314 h1:8BROw/Rye41WXwj9Bs0P0V1aUaVAMm++R+8Rla+v+WI=
+github.com/Deydra71/keystone-operator/api v0.0.0-20250428100042-040976c94314/go.mod h1:VPkYswnrCtlSMTeYjgxTOpfNN7zvxqa+kZ8EWDJaFrg=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
@@ -80,8 +82,6 @@ github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094 h1:J1wuGhVxpsHykZBa6
 github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
 github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250424140239-2d89c1d9f3ec h1:Sr12fbgiUTL/a7qvKCosedKW5gn5S+53DgRJgeveTk4=
 github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250424140239-2d89c1d9f3ec/go.mod h1:XywwuHkxaBZA+6QsF+N/3f9ekBq3tH0I/gQZzwL89GU=
-github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250424160141-6db2b5a653cf h1:RWYHdI5Aia5sUawoD8VgE98YUaQtqFsiQt6pRYMjN4g=
-github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250424160141-6db2b5a653cf/go.mod h1:VPkYswnrCtlSMTeYjgxTOpfNN7zvxqa+kZ8EWDJaFrg=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250423055245-3cb2ae8df6f0 h1:L2YsApIsUga1ku2siRM/kPViRNk756q+g7jrweAHkdo=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250423055245-3cb2ae8df6f0/go.mod h1:UwHXRIrMSPJD3lFqrA4oKmRXVLFQCRkLAj9x6KLEHiQ=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.6.1-0.20250423055245-3cb2ae8df6f0 h1:FAHrScvlj6w17wvcDhJ0ZnmraMrrOX1CxzvqZK595hA=

--- a/templates/barbican/config/00-default.conf
+++ b/templates/barbican/config/00-default.conf
@@ -12,15 +12,19 @@ connection={{ .DatabaseConnection }}
 
 {{ if (index . "KeystoneAuthURL") }}
 [keystone_authtoken]
-auth_version = v3
-auth_url={{ .KeystoneAuthURL }}
-auth_type=password
-username={{ .ServiceUser }}
-user_domain_name=Default
-password = {{ .ServicePassword }}
-project_name=service
-project_domain_name=Default
-interface = internal
+auth_url = {{ .KeystoneAuthURL }}
+auth_type = {{ if .UseApplicationCredentials }}v3applicationcredential{{ else }}password{{ end }}
+
+{{ if .UseApplicationCredentials -}}
+application_credential_id     = {{ .ACID }}
+application_credential_secret = {{ .ACSecret }}
+{{- else -}}
+username           = {{ .ServiceUser }}
+user_domain_name   = Default
+password           = {{ .ServicePassword }}
+project_name       = service
+project_domain_name= Default
+{{- end }}
 {{- end }}
 
 [oslo_messaging_notifications]


### PR DESCRIPTION
This PR adds end-to-end support for consuming Keystone ApplicationCredentials (AC) in the Barbican operator, enabling BarbicanAPI, BarbicanWorker and KeystoneListener to fall back to AC-based auth when available.

AC watches:
*`AddACWatches` registers watches on ApplicationCredential CRs and their corresponding Secrets (that are created by openstack-operator)
* Controllers enqueue a reconcile for any CR named `ac-<service>` and its `-secret` Secret

Reconcile logic:
* On each reconcile the controller looks for an ApplicationCredential CR
* If the CR is missing, it logs and will continue using password authentication
* If the CR exists but its Secret isn’t ready yet, it logs that it’s waiting and requeues

Once the Secret appears, it:
* Reads the AC_ID and AC_SECRET fields and injects them into the service’s configuration so the pod will authenticate with application credentials instead of a password.
* Computes a hash of the Secret’s contents and stores that in the status, changes trigger new hash computation and a rolling update of the Deployment whenever the credentials rotate.

SetupWithManager changes:
Adds field indexer for AC CR and AC Secret. 

Depends-On: https://github.com/openstack-k8s-operators/keystone-operator/pull/567