### PR TITLE
Leader election lease tunables

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ import (
 
 	barbicanv1beta1 "github.com/openstack-k8s-operators/barbican-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/barbican-operator/controllers"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/operator"
 
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
@@ -92,7 +93,7 @@ func main() {
 		c.NextProtos = []string{"http/1.1"}
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	options := ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
@@ -105,7 +106,15 @@ func main() {
 				Port:    9443,
 				TLSOpts: []func(config *tls.Config){disableHTTP2},
 			}),
-	})
+	}
+
+	err := operator.SetManagerOptions(&options, setupLog)
+	if err != nil {
+		setupLog.Error(err, "unable to set manager options")
+		os.Exit(1)
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)


### PR DESCRIPTION
Expose the leader election tunables for lease duration, renew deadline and retry period via environment variables.

This is inspired by rabbitmq operator exposes the same.

Jira: [OSPRH-16335](https://issues.redhat.com//browse/OSPRH-16335)

Depends-On: https://github.com/openstack-k8s-operators/lib-common/pull/627