### PR TITLE
[fr-3] Gracefully clean up old deployments with duplicate names

### DIFF
--- a/controllers/barbican_controller.go
+++ b/controllers/barbican_controller.go
@@ -47,6 +47,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/job"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/labels"
 	nad "github.com/openstack-k8s-operators/lib-common/modules/common/networkattachment"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/object"
 	common_rbac "github.com/openstack-k8s-operators/lib-common/modules/common/rbac"
 	oko_secret "github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
@@ -54,6 +55,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	"golang.org/x/exp/maps"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -1226,4 +1228,32 @@ func (r *BarbicanReconciler) ensureDB(
 	instance.Status.DatabaseHostname = db.GetDatabaseHostname()
 	instance.Status.Conditions.MarkTrue(condition.DBReadyCondition, condition.DBReadyMessage)
 	return db, ctrlResult, nil
+}
+
+func cleanupOldDeployment(
+	ctx context.Context,
+	c client.Client,
+	owner client.Object,
+	oldName string,
+) error {
+	// Retrieve the old deployment to check ownership
+	oldDep := &appsv1.Deployment{}
+	key := types.NamespacedName{
+		Name:      oldName,
+		Namespace: owner.GetNamespace(),
+	}
+	if err := c.Get(ctx, key, oldDep); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+
+	if !object.CheckOwnerRefExist(owner.GetUID(), oldDep.OwnerReferences) {
+		return nil
+	}
+
+	// If it’s owned, delete the old deployment
+	if err := c.Delete(ctx, oldDep); err != nil && !k8s_errors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete old deployment '%s': %w", oldName, err)
+	}
+
+	return nil
 }

--- a/controllers/barbicanapi_controller.go
+++ b/controllers/barbicanapi_controller.go
@@ -873,6 +873,10 @@ func (r *BarbicanAPIReconciler) reconcileNormal(ctx context.Context, instance *b
 	// In addition, make sure the controller sees the last Generation
 	// by comparing it with the ObservedGeneration.
 	if deployment.IsReady(deploy) {
+		oldDepName := fmt.Sprintf("%s-api", instance.Name)
+		if err := cleanupOldDeployment(ctx, r.Client, instance, oldDepName); err != nil {
+			return ctrl.Result{}, err
+		}
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
 	} else {
 		instance.Status.Conditions.Set(condition.FalseCondition(

--- a/controllers/barbicankeystonelistener_controller.go
+++ b/controllers/barbicankeystonelistener_controller.go
@@ -632,6 +632,10 @@ func (r *BarbicanKeystoneListenerReconciler) reconcileNormal(ctx context.Context
 	// In addition, make sure the controller sees the last Generation
 	// by comparing it with the ObservedGeneration.
 	if deployment.IsReady(deploy) {
+		oldDepName := fmt.Sprintf("%s-keystone-listener", instance.Name)
+		if err := cleanupOldDeployment(ctx, r.Client, instance, oldDepName); err != nil {
+			return ctrl.Result{}, err
+		}
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
 	} else {
 		instance.Status.Conditions.Set(condition.FalseCondition(

--- a/controllers/barbicanworker_controller.go
+++ b/controllers/barbicanworker_controller.go
@@ -630,6 +630,10 @@ func (r *BarbicanWorkerReconciler) reconcileNormal(ctx context.Context, instance
 	// In addition, make sure the controller sees the last Generation
 	// by comparing it with the ObservedGeneration.
 	if deployment.IsReady(deploy) {
+		oldDepName := fmt.Sprintf("%s-worker", instance.Name)
+		if err := cleanupOldDeployment(ctx, r.Client, instance, oldDepName); err != nil {
+			return ctrl.Result{}, err
+		}
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
 	} else {
 		instance.Status.Conditions.Set(condition.FalseCondition(


### PR DESCRIPTION
This is a cherry-pick of https://github.com/openstack-k8s-operators/barbican-operator/pull/231