### PR TITLE
[OSPRH-19982] Improve consistency of condition severity usage

### DIFF
--- a/controllers/barbicanworker_controller.go
+++ b/controllers/barbicanworker_controller.go
@@ -195,11 +195,27 @@ func (r *BarbicanWorkerReconciler) verifySecret(
 			err.Error()))
 		return ctrl.Result{}, err
 	} else if (result != ctrl.Result{}) {
+		// This function is used in different contexts, but only one of them, for the transport URL secret,
+		// involves a secret that is automatically created elsewhere.  For the other contexts, we treat this
+		// as a warning because it means that the service will not be able to start while we are waiting for
+		// the secret to be created manually by the user.
+
+		var reason condition.Reason
+		var severity condition.Severity
+
+		if expectedFields != nil && slices.Contains(expectedFields, TransportURL) {
+			reason = condition.RequestedReason
+			severity = condition.SeverityInfo
+		} else {
+			reason = condition.ErrorReason
+			severity = condition.SeverityWarning
+		}
+
 		Log.Info(fmt.Sprintf("OpenStack secret %s not found", secretName))
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.InputReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
+			reason,
+			severity,
 			condition.InputReadyWaitingMessage))
 		return result, nil
 	}
@@ -419,10 +435,12 @@ func (r *BarbicanWorkerReconciler) reconcileNormal(ctx context.Context, instance
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage,
 					instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
@@ -495,11 +513,13 @@ func (r *BarbicanWorkerReconciler) reconcileNormal(ctx context.Context, instance
 		nad, err := nad.GetNADWithName(ctx, helper, netAtt, instance.Namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the net-attach-def CR should have been manually created by the user and referenced in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				Log.Info(fmt.Sprintf("network-attachment-definition %s not found", netAtt))
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.NetworkAttachmentsReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.NetworkAttachmentsReadyWaitingMessage,
 					netAtt))
 				return ctrl.Result{RequeueAfter: time.Second * 10}, nil


### PR DESCRIPTION
Use consistent condition severity across repeated patterns found in our operators, and otherwise use an appropriate severity for conditions unique to each operator.

Jira: https://issues.redhat.com/browse/OSPRH-19982

Co-authored-by: Claude (Anthropic) [claude@anthropic.com](mailto:claude@anthropic.com)