### PR TITLE
Modernize Go code with latest style conventions

### DIFF
--- a/controllers/barbican_common.go
+++ b/controllers/barbican_common.go
@@ -36,7 +36,7 @@ import (
 
 type conditionUpdater interface {
 	Set(c *condition.Condition)
-	MarkTrue(t condition.Type, messageFormat string, messageArgs ...interface{})
+	MarkTrue(t condition.Type, messageFormat string, messageArgs ...any)
 }
 
 type topologyHandler interface {
@@ -89,7 +89,7 @@ func GenerateConfigsGeneric(
 	ctx context.Context, h *helper.Helper,
 	instance client.Object,
 	envVars *map[string]env.Setter,
-	templateParameters map[string]interface{},
+	templateParameters map[string]any,
 	customData map[string]string,
 	cmLabels map[string]string,
 	scripts bool,
@@ -123,7 +123,7 @@ func GenerateConfigsGeneric(
 func GenerateSecretStoreTemplateMap(
 	enabledSecretStores []barbicanv1beta1.SecretStore,
 	globalDefaultSecretStore barbicanv1beta1.SecretStore,
-) (map[string]interface{}, error) {
+) (map[string]any, error) {
 	// Log := r.GetLogger(ctx)
 	stores := []string{}
 	if len(enabledSecretStores) == 0 {
@@ -138,7 +138,7 @@ func GenerateSecretStoreTemplateMap(
 		globalDefaultSecretStore = "simple_crypto"
 	}
 
-	tempMap := map[string]interface{}{
+	tempMap := map[string]any{
 		"EnabledSecretStores":      strings.Join(stores, ","),
 		"GlobalDefaultSecretStore": globalDefaultSecretStore,
 		"SimpleCryptoEnabled":      slices.Contains(stores, "simple_crypto"),

--- a/controllers/barbicanapi_controller.go
+++ b/controllers/barbicanapi_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"time"
 
@@ -312,15 +313,10 @@ func (r *BarbicanAPIReconciler) generateServiceConfigs(
 		if err != nil {
 			return err
 		}
-		for key, data := range ownerInstance.Spec.DefaultConfigOverwrite {
-			customData[key] = data
-		}
+		maps.Copy(customData, ownerInstance.Spec.DefaultConfigOverwrite)
 	}
 
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		// can we merge here?
-		customData[key] = data
-	}
+	maps.Copy(customData, instance.Spec.DefaultConfigOverwrite)
 
 	customSecrets := ""
 	for _, secretName := range instance.Spec.CustomServiceConfigSecrets {
@@ -336,7 +332,7 @@ func (r *BarbicanAPIReconciler) generateServiceConfigs(
 
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"LogFile": fmt.Sprintf("%s%s.log", barbican.BarbicanLogPath, instance.Name),
 	}
 

--- a/controllers/barbicankeystonelistener_controller.go
+++ b/controllers/barbicankeystonelistener_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"time"
 
@@ -289,9 +290,7 @@ func (r *BarbicanKeystoneListenerReconciler) generateServiceConfigs(
 		// TODO(alee) Get custom config overwrites from the parent barbican
 	}
 
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		customData[key] = data
-	}
+	maps.Copy(customData, instance.Spec.DefaultConfigOverwrite)
 
 	customSecrets := ""
 	for _, secretName := range instance.Spec.CustomServiceConfigSecrets {
@@ -307,7 +306,7 @@ func (r *BarbicanKeystoneListenerReconciler) generateServiceConfigs(
 
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"LogFile": fmt.Sprintf("%s%s.log", barbican.BarbicanLogPath, instance.Name),
 	}
 

--- a/controllers/barbicanworker_controller.go
+++ b/controllers/barbicanworker_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"time"
 
@@ -282,9 +283,7 @@ func (r *BarbicanWorkerReconciler) generateServiceConfigs(
 		// TODO(alee) Get custom config overwrites from the parent barbican
 	}
 
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		customData[key] = data
-	}
+	maps.Copy(customData, instance.Spec.DefaultConfigOverwrite)
 
 	customSecrets := ""
 	for _, secretName := range instance.Spec.CustomServiceConfigSecrets {
@@ -300,7 +299,7 @@ func (r *BarbicanWorkerReconciler) generateServiceConfigs(
 
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"LogFile": fmt.Sprintf("%s%s.log", barbican.BarbicanLogPath, instance.Name),
 	}
 

--- a/tests/functional/barbican_controller_test.go
+++ b/tests/functional/barbican_controller_test.go
@@ -427,7 +427,7 @@ var _ = Describe("Barbican controller", func() {
 			spec := GetDefaultBarbicanSpec()
 			// Update the spec and add a top-level topologyRef that points to
 			// gloabal-topology
-			spec["topologyRef"] = map[string]interface{}{
+			spec["topologyRef"] = map[string]any{
 				"name": topologyRef.Name,
 			}
 			DeferCleanup(k8sClient.Delete, ctx, CreateBarbicanMessageBusSecret(barbicanTest.Instance.Namespace, "rabbitmq-secret"))
@@ -723,7 +723,7 @@ var _ = Describe("Barbican controller", func() {
 	When("A Barbican with nodeSelector is created", func() {
 		BeforeEach(func() {
 			spec := GetDefaultBarbicanSpec()
-			spec["nodeSelector"] = map[string]interface{}{
+			spec["nodeSelector"] = map[string]any{
 				"foo": "bar",
 			}
 			spec["barbicanAPI"] = GetDefaultBarbicanAPISpec()
@@ -1685,18 +1685,18 @@ var _ = Describe("Barbican Webhook", func() {
 	It("rejects with wrong BarbicanAPI service override endpoint type", func() {
 		spec := GetDefaultBarbicanSpec()
 		apiSpec := GetDefaultBarbicanAPISpec()
-		apiSpec["override"] = map[string]interface{}{
-			"service": map[string]interface{}{
-				"internal": map[string]interface{}{},
-				"wrooong":  map[string]interface{}{},
+		apiSpec["override"] = map[string]any{
+			"service": map[string]any{
+				"internal": map[string]any{},
+				"wrooong":  map[string]any{},
 			},
 		}
 		spec["barbicanAPI"] = apiSpec
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "barbican.openstack.org/v1beta1",
 			"kind":       "Barbican",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      barbicanTest.Instance.Name,
 				"namespace": barbicanTest.Instance.Namespace,
 			},
@@ -1723,24 +1723,24 @@ var _ = Describe("Barbican Webhook", func() {
 
 			// API, Worker and KeystoneListener
 			if component != "top-level" {
-				spec[component] = map[string]interface{}{
-					"topologyRef": map[string]interface{}{
+				spec[component] = map[string]any{
+					"topologyRef": map[string]any{
 						"name":      "bar",
 						"namespace": "foo",
 					},
 				}
 				// top-level topologyRef
 			} else {
-				spec["topologyRef"] = map[string]interface{}{
+				spec["topologyRef"] = map[string]any{
 					"name":      "bar",
 					"namespace": "foo",
 				}
 			}
 			// Build the barbican CR
-			raw := map[string]interface{}{
+			raw := map[string]any{
 				"apiVersion": "barbican.openstack.org/v1beta1",
 				"kind":       "Barbican",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      barbicanTest.Instance.Name,
 					"namespace": barbicanTest.Instance.Namespace,
 				},

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -52,8 +52,8 @@ func CreateCustomConfigSecret(namespace string, name string, contents map[string
 	)
 }
 
-func GetDefaultBarbicanSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultBarbicanSpec() map[string]any {
+	return map[string]any{
 		"databaseInstance":          "openstack",
 		"secret":                    SecretName,
 		"simpleCryptoBackendSecret": SecretName,
@@ -61,11 +61,11 @@ func GetDefaultBarbicanSpec() map[string]interface{} {
 	}
 }
 
-func CreateBarbican(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateBarbican(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "barbican.openstack.org/v1beta1",
 		"kind":       "Barbican",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -86,7 +86,7 @@ func CreateBarbicanMessageBusSecret(namespace string, name string) *corev1.Secre
 	s := th.CreateSecret(
 		types.NamespacedName{Namespace: namespace, Name: name},
 		map[string][]byte{
-			"transport_url": []byte(fmt.Sprintf("rabbit://%s/fake", name)),
+			"transport_url": fmt.Appendf(nil, "rabbit://%s/fake", name),
 		},
 	)
 	logger.Info("Secret created", "name", name)
@@ -181,8 +181,8 @@ func BarbicanWorkerConditionGetter(name types.NamespacedName) condition.Conditio
 }
 
 // ========== TLS Stuff ==============
-func GetTLSBarbicanSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetTLSBarbicanSpec() map[string]any {
+	return map[string]any{
 		"databaseInstance":          "openstack",
 		"secret":                    SecretName,
 		"simpleCryptoBackendSecret": SecretName,
@@ -192,15 +192,15 @@ func GetTLSBarbicanSpec() map[string]interface{} {
 	}
 }
 
-func GetTLSBarbicanAPISpec() map[string]interface{} {
+func GetTLSBarbicanAPISpec() map[string]any {
 	spec := GetDefaultBarbicanAPISpec()
-	maps.Copy(spec, map[string]interface{}{
-		"tls": map[string]interface{}{
-			"api": map[string]interface{}{
-				"internal": map[string]interface{}{
+	maps.Copy(spec, map[string]any{
+		"tls": map[string]any{
+			"api": map[string]any{
+				"internal": map[string]any{
 					"secretName": InternalCertSecretName,
 				},
-				"public": map[string]interface{}{
+				"public": map[string]any{
 					"secretName": PublicCertSecretName,
 				},
 			},
@@ -231,13 +231,13 @@ key_wrap_generate_iv = true
 always_set_cka_sensitive = true
 os_locking_ok = false`
 
-func GetPKCS11BarbicanSpec() map[string]interface{} {
+func GetPKCS11BarbicanSpec() map[string]any {
 	spec := GetDefaultBarbicanSpec()
-	maps.Copy(spec, map[string]interface{}{
+	maps.Copy(spec, map[string]any{
 		"customServiceConfig":      PKCS11CustomData,
 		"enabledSecretStores":      []string{"pkcs11"},
 		"globalDefaultSecretStore": "pkcs11",
-		"pkcs11": map[string]interface{}{
+		"pkcs11": map[string]any{
 			"clientDataPath":   PKCS11ClientDataPath,
 			"loginSecret":      PKCS11LoginSecret,
 			"clientDataSecret": PKCS11ClientDataSecret,
@@ -246,7 +246,7 @@ func GetPKCS11BarbicanSpec() map[string]interface{} {
 	return spec
 }
 
-func GetPKCS11BarbicanAPISpec() map[string]interface{} {
+func GetPKCS11BarbicanAPISpec() map[string]any {
 	spec := GetPKCS11BarbicanSpec()
 	maps.Copy(spec, GetDefaultBarbicanAPISpec())
 	return spec
@@ -276,8 +276,8 @@ func CreatePKCS11ClientDataSecret(namespace string, name string) *corev1.Secret 
 
 // ========== End of PKCS11 Stuff ============
 
-func GetDefaultBarbicanAPISpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultBarbicanAPISpec() map[string]any {
+	return map[string]any{
 		"secret":                    SecretName,
 		"simpleCryptoBackendSecret": SecretName,
 		"replicas":                  1,
@@ -291,13 +291,13 @@ func GetDefaultBarbicanAPISpec() map[string]interface{} {
 	}
 }
 
-func CreateBarbicanAPI(name types.NamespacedName, spec map[string]interface{}) client.Object {
+func CreateBarbicanAPI(name types.NamespacedName, spec map[string]any) client.Object {
 	// we get the parent CR and set ownership to the barbicanAPI CR
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "barbican.openstack.org/v1beta1",
 		"kind":       "BarbicanAPI",
-		"metadata": map[string]interface{}{
-			"annotations": map[string]interface{}{
+		"metadata": map[string]any{
+			"annotations": map[string]any{
 				"keystoneEndpoint": "true",
 			},
 			"name":      name.Name,
@@ -346,16 +346,16 @@ func GetBarbicanWorkerSpec(name types.NamespacedName) barbicanv1.BarbicanWorkerT
 // multi AZ, which is not applicable in this context
 func GetSampleTopologySpec(
 	label string,
-) (map[string]interface{}, []corev1.TopologySpreadConstraint) {
+) (map[string]any, []corev1.TopologySpreadConstraint) {
 	// Build the topology Spec
-	topologySpec := map[string]interface{}{
-		"topologySpreadConstraints": []map[string]interface{}{
+	topologySpec := map[string]any{
+		"topologySpreadConstraints": []map[string]any{
 			{
 				"maxSkew":           1,
 				"topologyKey":       corev1.LabelHostname,
 				"whenUnsatisfiable": "ScheduleAnyway",
-				"labelSelector": map[string]interface{}{
-					"matchLabels": map[string]interface{}{
+				"labelSelector": map[string]any{
+					"matchLabels": map[string]any{
 						"component": label,
 					},
 				},


### PR DESCRIPTION
Modernize using `gopls modernize tool` to update:

- Replace interface{} with any type alias (Go 1.18+)
- Update range loops to use idiomatic range syntax
- Replace fmt.Sprintf with fmt.Appendf where appropriate

These changes improve code readability and align with current Go best practices.

Co-Authored-By: Claude <noreply@anthropic.com>