### PR TITLE
Bump golangci-lint to 2.7.2 for barbican

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
       entry: bashate --error . --ignore=E006,E040,E011,E020,E012
 
 - repo: https://github.com/golangci/golangci-lint
-  rev: v2.6.1
+  rev: v2.7.2
   hooks:
     - id: golangci-lint-full
       args: ["-v"]


### PR DESCRIPTION
## Summary
-Bump golangci-lint to 2.7.2