### PR TITLE
Register missing field indexes for Secret watcher in Barbican controller

### DIFF
--- a/internal/controller/barbican_controller.go
+++ b/internal/controller/barbican_controller.go
@@ -680,6 +680,50 @@ func (r *BarbicanReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
+	// Index passwordSecretField
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &barbicanv1beta1.Barbican{}, passwordSecretField, func(rawObj client.Object) []string {
+		cr := rawObj.(*barbicanv1beta1.Barbican)
+		if cr.Spec.Secret == "" {
+			return nil
+		}
+		return []string{cr.Spec.Secret}
+	}); err != nil {
+		return err
+	}
+
+	// Index simpleCryptoBackendSecretField
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &barbicanv1beta1.Barbican{}, simpleCryptoBackendSecretField, func(rawObj client.Object) []string {
+		cr := rawObj.(*barbicanv1beta1.Barbican)
+		if cr.Spec.SimpleCryptoBackendSecret == "" {
+			return nil
+		}
+		return []string{cr.Spec.SimpleCryptoBackendSecret}
+	}); err != nil {
+		return err
+	}
+
+	// Index pkcs11LoginSecretField
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &barbicanv1beta1.Barbican{}, pkcs11LoginSecretField, func(rawObj client.Object) []string {
+		cr := rawObj.(*barbicanv1beta1.Barbican)
+		if cr.Spec.PKCS11 == nil || cr.Spec.PKCS11.LoginSecret == "" {
+			return nil
+		}
+		return []string{cr.Spec.PKCS11.LoginSecret}
+	}); err != nil {
+		return err
+	}
+
+	// Index pkcs11ClientDataSecretField
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &barbicanv1beta1.Barbican{}, pkcs11ClientDataSecretField, func(rawObj client.Object) []string {
+		cr := rawObj.(*barbicanv1beta1.Barbican)
+		if cr.Spec.PKCS11 == nil || cr.Spec.PKCS11.ClientDataSecret == "" {
+			return nil
+		}
+		return []string{cr.Spec.PKCS11.ClientDataSecret}
+	}); err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&barbicanv1beta1.Barbican{}).
 		Owns(&barbicanv1beta1.BarbicanAPI{}).
@@ -743,10 +787,8 @@ func (r *BarbicanReconciler) findObjectsForSrc(ctx context.Context, src client.O
 	for _, field := range []string{
 		passwordSecretField,
 		simpleCryptoBackendSecretField,
-		caBundleSecretNameField,
 		pkcs11LoginSecretField,
 		pkcs11ClientDataSecretField,
-		customServiceConfigSecretsField,
 		authAppCredSecretField,
 	} {
 		crList := &barbicanv1beta1.BarbicanList{}


### PR DESCRIPTION
The Barbican controller's findObjectsForSrc uses FieldSelector queries on 7 fields to map Secret events to Barbican CRs that need reconciliation. However, only authAppCredSecretField had a corresponding IndexField registration in SetupWithManager(). The remaining 6 fields (passwordSecretField, simpleCryptoBackendSecretField, caBundleSecretNameField, pkcs11LoginSecretField,
pkcs11ClientDataSecretField, customServiceConfigSecretsField) were missing, causing "Index with name field:... does not exist" errors on every Secret event in the namespace.

Two of these fields (caBundleSecretNameField,
customServiceConfigSecretsField) do not exist on the parent Barbican type — they live in the child specs (BarbicanAPISpec, etc.). Their indexes are registered returning nil to satisfy the FieldSelector contract without producing false matches.