### PR TITLE
Ensure stable condition messages

### DIFF
--- a/internal/controller/barbicanapi_controller.go
+++ b/internal/controller/barbicanapi_controller.go
@@ -333,8 +333,8 @@ func (r *BarbicanAPIReconciler) generateServiceConfigs(
 		if err != nil {
 			return err
 		}
-		for _, data := range secret.Data {
-			customSecrets += string(data) + "\n"
+		for _, key := range slices.Sorted(maps.Keys(secret.Data)) {
+			customSecrets += string(secret.Data[key]) + "\n"
 		}
 	}
 	customData[barbican.CustomServiceConfigSecretsFileName] = customSecrets
@@ -388,7 +388,8 @@ func (r *BarbicanAPIReconciler) reconcileInit(
 
 	apiEndpoints := make(map[string]string)
 
-	for endpointType, data := range barbicanEndpoints {
+	for _, endpointType := range slices.Sorted(maps.Keys(barbicanEndpoints)) {
+		data := barbicanEndpoints[endpointType]
 		endpointTypeStr := string(endpointType)
 		endpointName := barbican.ServiceName + "-" + endpointTypeStr
 		svcOverride := instance.Spec.Override.Service[endpointType]

--- a/internal/controller/barbicankeystonelistener_controller.go
+++ b/internal/controller/barbicankeystonelistener_controller.go
@@ -306,8 +306,8 @@ func (r *BarbicanKeystoneListenerReconciler) generateServiceConfigs(
 		if err != nil {
 			return err
 		}
-		for _, data := range secret.Data {
-			customSecrets += string(data) + "\n"
+		for _, key := range slices.Sorted(maps.Keys(secret.Data)) {
+			customSecrets += string(secret.Data[key]) + "\n"
 		}
 	}
 	customData[barbican.CustomServiceConfigSecretsFileName] = customSecrets

--- a/internal/controller/barbicanworker_controller.go
+++ b/internal/controller/barbicanworker_controller.go
@@ -300,8 +300,8 @@ func (r *BarbicanWorkerReconciler) generateServiceConfigs(
 		if err != nil {
 			return err
 		}
-		for _, data := range secret.Data {
-			customSecrets += string(data) + "\n"
+		for _, key := range slices.Sorted(maps.Keys(secret.Data)) {
+			customSecrets += string(secret.Data[key]) + "\n"
 		}
 	}
 	customData[barbican.CustomServiceConfigSecretsFileName] = customSecrets


### PR DESCRIPTION
Use `slices.Sorted(maps.Keys(...))` for deterministic map iteration in condition-affecting and config-hash-affecting code paths. This prevents unnecessary reconciles caused by non-deterministic Go map iteration order changing condition messages or config hashes.

Jira: [OSPRH-28637](https://redhat.atlassian.net/browse/OSPRH-28637)