### PR TITLE
keystone-listener: enable allow_requeue for project delete events

### DIFF
--- a/templates/barbicankeystonelistener/config/01-service-defaults.conf
+++ b/templates/barbicankeystonelistener/config/01-service-defaults.conf
@@ -4,3 +4,4 @@ log_file = {{ .LogFile }}
 [keystone_notifications]
 enable = true
 topic = barbican_notifications
+allow_requeue = true


### PR DESCRIPTION
## Summary

- Set `allow_requeue = true` in the Keystone listener config template
- Without this, a transient failure during project-delete cleanup (e.g. DB blip) silently drops the notification, leaving orphaned Barbican resources (secrets, containers, KEK data, ACLs) with no automatic recovery
- With requeue enabled, the oslo.messaging transport retries delivery until the cleanup succeeds

## Test plan

- [ ] Deploy barbican-operator with this change
- [ ] Delete a Keystone project that has Barbican secrets
- [ ] Verify Barbican resources are cleaned up
- [ ] Simulate a transient failure (e.g. brief DB disconnect) during a project delete and verify the notification is requeued and eventually processed

🤖 Generated with [Claude Code](https://claude.com/claude-code)