### PR TITLE
Remove eval and xtrace from PKCS11 key generation script

### DIFF
--- a/templates/barbican/bin/generate_pkcs11_keys.sh
+++ b/templates/barbican/bin/generate_pkcs11_keys.sh
@@ -13,15 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-set -xe
+set -e
 
 {{- if and (index . "PKCS11Enabled") .PKCS11Enabled }}
 
-eval mkek_label=$(crudini --get /etc/barbican/barbican.conf.d/01-custom.conf p11_crypto_plugin mkek_label)
+mkek_label=$(crudini --get /etc/barbican/barbican.conf.d/01-custom.conf p11_crypto_plugin mkek_label)
 echo "Creating  MKEK label $mkek_label"
-barbican-manage hsm check_mkek --label $mkek_label || barbican-manage hsm gen_mkek --label $mkek_label
+barbican-manage hsm check_mkek --label "$mkek_label" || barbican-manage hsm gen_mkek --label "$mkek_label"
 
-eval hmac_label=$(crudini --get /etc/barbican/barbican.conf.d/01-custom.conf p11_crypto_plugin hmac_label)
+hmac_label=$(crudini --get /etc/barbican/barbican.conf.d/01-custom.conf p11_crypto_plugin hmac_label)
 echo "Creating  HMAC label $hmac_label"
-barbican-manage hsm check_hmac --label $hmac_label || barbican-manage hsm gen_hmac --label $hmac_label
+barbican-manage hsm check_hmac --label "$hmac_label" || barbican-manage hsm gen_hmac --label "$hmac_label"
 {{- end }}


### PR DESCRIPTION
Remove unnecessary eval from crudini variable assignments — direct command substitution works the same without shell interpretation of the result. Remove -x from set -xe to prevent echoing of HSM PIN values to stdout/logs. Quote variable expansions in barbican-manage arguments.

Jira: [OSPRH-31726](https://redhat.atlassian.net/browse/OSPRH-31726)