### PR TITLE
Set service_type in [keystone_authtoken] for access rule validation

### DIFF
--- a/templates/barbican/config/00-default.conf
+++ b/templates/barbican/config/00-default.conf
@@ -27,6 +27,7 @@ project_name=service
 project_domain_name=Default
 {{- end }}
 interface = internal
+service_type = key-manager
 {{ if (index . "Region") -}}
 region_name = {{ .Region }}
 {{ end -}}


### PR DESCRIPTION
Without service_type configured, keystonemiddleware cannot validate application credentials with custom access rules, causing HTTP 401 for end users.

Closes: [OSPRH-22365](https://redhat.atlassian.net/browse/OSPRH-22365)