### PR TITLE
Fix client IP logging in Barbican API VirtualHost

### DIFF
--- a/templates/barbican/config/10-barbican_wsgi_main.conf
+++ b/templates/barbican/config/10-barbican_wsgi_main.conf
@@ -17,9 +17,11 @@
   </Directory>
 
   ## Logging
-  ErrorLog "/var/log/barbican/error.log"
+  ErrorLog /dev/stdout
   ServerSignature Off
-  CustomLog "/var/log/barbican/access.log" combined env=!forwarded
+  SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+  CustomLog /dev/stdout combined env=!forwarded
+  CustomLog /dev/stdout proxy env=forwarded
 
 {{- if $vhost.TLS }}
   SetEnvIf X-Forwarded-Proto https HTTPS=1

--- a/templates/barbican/config/httpd.conf
+++ b/templates/barbican/config/httpd.conf
@@ -34,12 +34,11 @@
 
          Include "/etc/httpd/conf.modules.d/*.conf"
 
-         LogFormat "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
-         LogFormat "%a %l %u %t \"%r\" %>s %b" common
-         LogFormat "%{Referer}i -> %U" referer
-         LogFormat "%{User-agent}i" agent
-         LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-agent}i\"" forwarded
+         LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+         LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy
 
-         CustomLog "/var/log/barbican/access.log" combined env=!forwarded
-         ErrorLog "/var/log/barbican/error.log"
+         SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+         CustomLog /dev/stdout combined env=!forwarded
+         CustomLog /dev/stdout proxy env=forwarded
+         ErrorLog /dev/stdout
          IncludeOptional "/etc/httpd/conf.d/*.conf"


### PR DESCRIPTION
The `VirtualHost` `CustomLog` directive was overriding the server-level dual-log setup, causing all requests to be logged with the OpenShift router IP instead of the real client IP from `X-Forwarded-For`.

Add `SetEnvIf` and dual `CustomLog` lines inside the `VirtualHost` block to match the `nova-operator` pattern.

Jira: [OSPRH-32126](https://redhat.atlassian.net/browse/OSPRH-32126)