### PR TITLE
Remove deprecated webhook.Defaulter/Validator interface assertions

### DIFF
--- a/api/v1beta1/barbican_webhook.go
+++ b/api/v1beta1/barbican_webhook.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -56,8 +55,6 @@ func SetupBarbicanDefaults(defaults BarbicanDefaults) {
 	barbicanDefaults = defaults
 	barbicanlog.Info("Barbican defaults initialized", "defaults", defaults)
 }
-
-var _ webhook.Defaulter = &Barbican{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Barbican) Default() {
@@ -98,8 +95,6 @@ func (spec *BarbicanSpecCore) Default() {
 	}
 	spec.BarbicanSpecBase.Default()
 }
-
-var _ webhook.Validator = &Barbican{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Barbican) ValidateCreate() (admission.Warnings, error) {


### PR DESCRIPTION
These compile-time assertions reference webhook.Defaulter and webhook.Validator interfaces that are removed in controller-runtime v0.21 (OCP 4.20). The assertions are dead code — webhook registration already uses CustomDefaulter/CustomValidator in internal/webhook/.

Removing them makes the API module forward-compatible with CR v0.21 so that consumers (like openstack-operator) can bump controller-runtime without needing replace directives for this operator.

Jira: [OSPRH-32989](https://redhat.atlassian.net/browse/OSPRH-32989)