### PR TITLE
Restore pods RBAC needed for NetworkAttachments verification

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,6 +21,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
   verbs:
   - create

--- a/internal/controller/barbican_controller.go
+++ b/internal/controller/barbican_controller.go
@@ -113,6 +113,7 @@ func (r *BarbicanReconciler) GetLogger(ctx context.Context) logr.Logger {
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete;
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete;
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete;
+//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list
 //+kubebuilder:rbac:groups=rabbitmq.openstack.org,resources=transporturls,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=mariadb.openstack.org,resources=mariadbaccounts,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
Commit 31d93a8 ("Remove unnecessary pods RBAC permissions") dropped the pods kubebuilder RBAC marker from barbican_controller.go. BarbicanAPI, BarbicanWorker and BarbicanKeystoneListener never declared their own pods marker and relied on this one, and all three call lib-common's VerifyNetworkStatusFromAnnotation to verify NetworkAttachments. That function lists Pods using the controller-manager's own client, so the manager's ClusterRole (config/rbac/role.yaml) needs get;list on pods or those services get stuck in NetworkAttachmentsReady=False with a "pods is forbidden" error, as seen on manila/cinder/neutron-operator after the same cleanup. Restore the get;list marker and regenerate config/rbac/role.yaml. The unused rbacRules grant on the workload service account remains removed, since that really is unused.