### PR TITLE
[18-stable] Remove unnecessary pods RBAC permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,7 +8,6 @@ rules:
   - ""
   resources:
   - configmaps
-  - pods
   - secrets
   - services
   verbs:
@@ -19,6 +18,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
 - apiGroups:
   - ""
   resources:

--- a/internal/controller/barbican_controller.go
+++ b/internal/controller/barbican_controller.go
@@ -113,7 +113,7 @@ func (r *BarbicanReconciler) GetLogger(ctx context.Context) logr.Logger {
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete;
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete;
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete;
-//+kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list
 //+kubebuilder:rbac:groups=rabbitmq.openstack.org,resources=transporturls,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=mariadb.openstack.org,resources=mariadbaccounts,verbs=get;list;watch;create;update;patch;delete
@@ -1251,11 +1251,6 @@ func (r *BarbicanReconciler) reconcileInit(
 			ResourceNames: []string{"anyuid"},
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
-		},
-		{
-			APIGroups: []string{""},
-			Resources: []string{"pods"},
-			Verbs:     []string{"create", "get", "list", "watch", "update", "patch", "delete"},
 		},
 	}
 	rbacResult, err := common_rbac.ReconcileRbac(ctx, helper, instance, rbacRules)


### PR DESCRIPTION
The workload rbacRules and the matching kubebuilder RBAC marker in the controller granted the workload service account full CRUD (create/delete/get/list/patch/update/watch) on core Pods, but that service account never reads or writes Pod objects directly. Remove the unused grants.

The kubebuilder RBAC marker for pods (get;list) is kept: lib-common's VerifyNetworkStatusFromAnnotation, called from this controller to verify NetworkAttachments, lists Pods using the controller-manager's own client, so the manager's ClusterRole (config/rbac/role.yaml) still needs get;list on pods. Regenerate config/rbac/role.yaml.

Includes b3f8fc57596cd4a336ee432b5a250fb991ecd6ab


(cherry picked from commit 31d93a863945b238c68535230219f54ccfe61293)