### PR TITLE
Debug logging off by default

### DIFF
--- a/templates/barbican/config/00-default.conf
+++ b/templates/barbican/config/00-default.conf
@@ -1,7 +1,6 @@
 [DEFAULT]
 # keep this for backward compatibility
 sql_connection = {{ .DatabaseConnection }}
-debug = true
 transport_url = {{ .TransportURL }}
 log_file = {{ .LogFile }}
 

--- a/templates/barbican/config/httpd.conf
+++ b/templates/barbican/config/httpd.conf
@@ -29,7 +29,7 @@
 
 
          HostnameLookups Off
-         LogLevel debug
+         LogLevel warn
          EnableSendfile On
 
          Include "/etc/httpd/conf.modules.d/*.conf"


### PR DESCRIPTION
Operator templates shipped debug = true and httpd LogLevel debug, so every deployment was verbose by default (noise + possible sensitive data in logs). 

Defaults `debug = false` and `LogLevel warn` (as in e.g. octavia’s httpd and other services). Pods get non-debug logging unless the user overrides via custom config.